### PR TITLE
Adjust error wording and output to include "how do I fix this?"

### DIFF
--- a/lib/motion/errors.rb
+++ b/lib/motion/errors.rb
@@ -81,7 +81,7 @@ module Motion
         Detected nested component in state. Motion does not allow storing
         Component objects in the state of your Components.
 
-        Read more: https://github.com/unabridged/motion/wiki/Using-Nested-Components
+        Read more: https://github.com/unabridged/motion/wiki/NestedComponentInStateError
 
         Fix:
           * To communicate from parent to child, instantiate child components


### PR DESCRIPTION
Error messages are useful places to help devs figure out what they did wrong and how they can fix it. All error messages now include a tip for what can be done to resolve them.