### PR TITLE
`current_event` API

### DIFF
--- a/lib/motion/component/motions.rb
+++ b/lib/motion/component/motions.rb
@@ -34,10 +34,12 @@ module Motion
           raise MotionNotMapped.new(self, motion)
         end
 
-        if method(handler).arity.zero?
-          send(handler)
-        else
-          send(handler, event)
+        _with_current_event(event) do
+          if method(handler).arity.zero?
+            send(handler)
+          else
+            send(handler, event)
+          end
         end
       end
 
@@ -54,6 +56,18 @@ module Motion
         return @_motion_handlers if defined?(@_motion_handlers)
 
         self.class._motion_handlers
+      end
+
+      def current_event
+        @_current_event
+      end
+
+      def _with_current_event(event)
+        @_current_event = event
+
+        yield
+      ensure
+        remove_instance_variable(:@_current_event)
       end
     end
   end


### PR DESCRIPTION
I'm torn about whether this API is a good idea.

:+1: It allows you to write helper methods for getting information out of events without passing arguments.
:-1: `current_event` doesn't really make sense to call outside of a motion, but it is always defined. Is that confusing?