### PR TITLE
Allow broadcast handlers with no arguments

### DIFF
--- a/lib/motion/component/broadcasts.rb
+++ b/lib/motion/component/broadcasts.rb
@@ -58,7 +58,11 @@ module Motion
       def process_broadcast(broadcast, message)
         return unless (handler = _broadcast_handlers[broadcast])
 
-        send(handler, message)
+        if method(handler).arity.zero?
+          send(handler)
+        else
+          send(handler, message)
+        end
       end
 
       def broadcast_to(model, message)

--- a/spec/motion/component/broadcasts_spec.rb
+++ b/spec/motion/component/broadcasts_spec.rb
@@ -104,6 +104,36 @@ RSpec.describe Motion::Component::Broadcasts do
         subject
       end
     end
+
+    context "for a broadcast that takes a message" do
+      let(:broadcast) { "noop_with_arg" }
+
+      it "calls the handler with the message" do
+        expect(component).to receive(:noop_with_arg).with(message)
+        subject
+      end
+    end
+
+    context "for a broadcast that does not take a message" do
+      let(:broadcast) { "noop_without_arg" }
+
+      it "calls the handler without the argument" do
+        # Sadly, the way rspec's mocking works, this will change the arity:
+        #   expect(component).to receive(:noop_without_event).with(no_args)
+        #
+        # Instead we roll out own watcher that we know will take 0 args:
+        called = false
+
+        component.define_singleton_method(:noop_without_arg) do
+          called = true
+          super()
+        end
+
+        subject
+
+        expect(called).to be(true)
+      end
+    end
   end
 
   describe "#broadcast_to" do

--- a/spec/motion/component/motions_spec.rb
+++ b/spec/motion/component/motions_spec.rb
@@ -44,16 +44,16 @@ RSpec.describe Motion::Component::Motions do
     let(:event) { Motion::Event.new({}) }
 
     context "for a motion that takes an event" do
-      let(:motion) { "noop_with_event" }
+      let(:motion) { "noop_with_arg" }
 
       it "calls the handler with the event" do
-        expect(component).to receive(:noop_with_event).with(event)
+        expect(component).to receive(:noop_with_arg).with(event)
         subject
       end
     end
 
     context "for a motion that does not take an event" do
-      let(:motion) { "noop_without_event" }
+      let(:motion) { "noop_without_arg" }
 
       it "calls the handler without the event" do
         # Sadly, the way rspec's mocking works, this will change the arity:
@@ -62,7 +62,7 @@ RSpec.describe Motion::Component::Motions do
         # Instead we roll out own watcher that we know will take 0 args:
         called = false
 
-        component.define_singleton_method(:noop_without_event) do
+        component.define_singleton_method(:noop_without_arg) do
           called = true
           super()
         end

--- a/spec/support/test_application.rb
+++ b/spec/support/test_application.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "fileutils"
-require "json"
-
 # Load the TestApplication environment into this Ruby process
 require_relative "test_application/config/environment"
 
@@ -11,7 +8,7 @@ TestApplication.load_generators
 
 # Add a helper method to sync the JavaScript in the test app with the outer gem.
 class << TestApplication
-  def TestApplication.sync_motion_client!
+  def sync_motion_client!
     return if @synced_motion_client
 
     yarn! "--cwd", "../../..", "link"
@@ -31,14 +28,12 @@ class << TestApplication
   end
 
   def yarn!(*args)
-    root_path = File.expand_path(Rails.root)
-
     stdout, stderr, status =
-      Open3.capture3("bin/yarn", *args, chdir: root_path)
+      Open3.capture3("bin/yarn", *args, chdir: Rails.root)
 
     unless status.success?
       short_output = [stdout, stderr].delete_if(&:empty?).join("\n\n")
-      raise "Failed to #{command}! Yarn says:\n#{short_output}"
+      raise "Failed to `yarn #{args.join(" ")}`! Yarn says:\n#{short_output}"
     end
   end
 end

--- a/spec/support/test_component.rb
+++ b/spec/support/test_component.rb
@@ -9,8 +9,8 @@ class TestComponent < ViewComponent::Base
   # used by tests that want to know the initial motions
   STATIC_MOTIONS = %w[
     noop
-    noop_with_event
-    noop_without_event
+    noop_with_arg
+    noop_without_arg
     change_state
     force_rerender
     setup_dynamic_motion
@@ -22,6 +22,8 @@ class TestComponent < ViewComponent::Base
   # used by tests that want to know the initial broadcasts
   STATIC_BROADCASTS = %w[
     noop
+    noop_with_arg
+    noop_without_arg
     change_state
     force_rerender
     setup_dynamic_motion
@@ -68,14 +70,16 @@ class TestComponent < ViewComponent::Base
   def noop(*)
   end
 
-  map_motion :noop_with_event
+  stream_from "noop_with_arg", :noop_with_arg
+  map_motion :noop_with_arg
 
-  def noop_with_event(_event)
+  def noop_with_arg(_event_or_message)
   end
 
-  map_motion :noop_without_event
+  stream_from "noop_without_arg", :noop_without_arg
+  map_motion :noop_without_arg
 
-  def noop_without_event
+  def noop_without_arg
   end
 
   stream_from "change_state", :change_state


### PR DESCRIPTION
This removes a minor inconsistency between events and motions that I noticed while working on AnyCable integration.

Currently, it is possible to define a motion handler which takes no arguments but it is not possible to do the same with broadcast handlers:
```ruby
# This is valid
map_motion :do_the_thing

# This is not
stream_from "things", :do_the_thing

def do_the_thing
end
```

I think it makes sense to allow reusing a handler for a motion and broadcast, so this PR allows broadcast handlers that take no argument.