### PR TITLE
Periodic timers ⏰

### DIFF
--- a/lib/motion/action_cable_extentions.rb
+++ b/lib/motion/action_cable_extentions.rb
@@ -4,10 +4,16 @@ require "motion"
 
 module Motion
   module ActionCableExtentions
+    autoload :DeclarativeNotifications,
+      "motion/action_cable_extentions/declarative_notifications"
+
     autoload :DeclarativeStreams,
       "motion/action_cable_extentions/declarative_streams"
 
     autoload :LogSuppression,
       "motion/action_cable_extentions/log_suppression"
+
+    autoload :Synchronization,
+      "motion/action_cable_extentions/synchronization"
   end
 end

--- a/lib/motion/action_cable_extentions/declarative_notifications.rb
+++ b/lib/motion/action_cable_extentions/declarative_notifications.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "motion"
+
+module Motion
+  module ActionCableExtentions
+    # Provides a `periodicly_notify(broadcasts, to:)` API that can be used to
+    # declaratively specify when a handler should be called.
+    module DeclarativeNotifications
+      include Synchronization
+
+      def initialize(*)
+        super
+
+        # The current set of declartive notifications
+        @_declarative_notifications = {}
+
+        # The active timers for the declartive notifications
+        @_declarative_notification_timers = {}
+
+        # The method we are routing declarative notifications to
+        @_declarative_notifications_target = nil
+      end
+
+      def declarative_notifications
+        @_declarative_notifications.keys
+      end
+
+      def periodicly_notify(notifications, via:)
+        (@_declarative_notifications.to_a - notifications.to_a)
+          .each do |notification, _interval|
+            _shutdown_declarative_notifcation_timer(notification)
+          end
+
+        (notifications.to_a - @_declarative_notifications.to_a)
+          .each do |notification, interval|
+            _setup_declarative_notifcation_timer(notification, interval)
+          end
+
+        @_declarative_notifications.replace(notifications)
+        @_declarative_notifications_target = via
+      end
+
+      private
+
+      def stop_periodic_timers
+        super
+
+        @_declarative_notification_timers.clear
+      end
+
+      # Sadly, the only public interface in ActionCable for defining periodic
+      # timers is exposed at the class level. Looking at the source though,
+      # it is easy to see that new timers can be setup with
+      # `start_periodic_timer`. To ensure that we do not leak any timers, it is
+      # important to store these intances in `active_periodic_timers` so that
+      # ActionCable cleans them up for use when the channel shuts down.
+      #
+      # See `ActionCable::Channel::PeriodicTimers` for details.
+      def _setup_declarative_notifcation_timer(notification, interval)
+        return if connection.is_a?(ActionCable::Channel::ConnectionStub) ||
+          @_declarative_notification_timers.include?(notification)
+
+        callback = proc do
+          synchronize_entrypoint! do
+            _handle_declarative_notifcation(notification)
+          end
+        end
+
+        timer = start_periodic_timer(callback, every: interval)
+
+        @_declarative_notification_timers[notification] = timer
+        active_periodic_timers << timer
+      end
+
+      def _shutdown_declarative_notifcation_timer(notification, *)
+        timer = @_declarative_notification_timers.delete(notification)
+        return unless timer
+
+        timer.shutdown
+        active_periodic_timers.delete(timer)
+      end
+
+      def _handle_declarative_notifcation(notification)
+        return unless @_declarative_notifications_target &&
+          @_declarative_notifications.include?(notification)
+
+        send(@_declarative_notifications_target, notification)
+      end
+    end
+  end
+end

--- a/lib/motion/action_cable_extentions/declarative_notifications.rb
+++ b/lib/motion/action_cable_extentions/declarative_notifications.rb
@@ -4,7 +4,7 @@ require "motion"
 
 module Motion
   module ActionCableExtentions
-    # Provides a `periodicly_notify(broadcasts, to:)` API that can be used to
+    # Provides a `periodically_notify(broadcasts, to:)` API that can be used to
     # declaratively specify when a handler should be called.
     module DeclarativeNotifications
       include Synchronization
@@ -23,10 +23,10 @@ module Motion
       end
 
       def declarative_notifications
-        @_declarative_notifications.keys
+        @_declarative_notifications
       end
 
-      def periodicly_notify(notifications, via:)
+      def periodically_notify(notifications, via:)
         (@_declarative_notifications.to_a - notifications.to_a)
           .each do |notification, _interval|
             _shutdown_declarative_notifcation_timer(notification)
@@ -46,15 +46,18 @@ module Motion
       def stop_periodic_timers
         super
 
+        @_declarative_notifications.clear
         @_declarative_notification_timers.clear
+        @_declarative_notifications_target = nil
       end
 
       # Sadly, the only public interface in ActionCable for defining periodic
       # timers is exposed at the class level. Looking at the source though,
       # it is easy to see that new timers can be setup with
       # `start_periodic_timer`. To ensure that we do not leak any timers, it is
-      # important to store these intances in `active_periodic_timers` so that
-      # ActionCable cleans them up for use when the channel shuts down.
+      # important to store these instances in `active_periodic_timers` so that
+      # ActionCable cleans them up for use when the channel shuts down. Also,
+      # periodic timers are not supported in testing.
       #
       # See `ActionCable::Channel::PeriodicTimers` for details.
       def _setup_declarative_notifcation_timer(notification, interval)

--- a/lib/motion/action_cable_extentions/declarative_streams.rb
+++ b/lib/motion/action_cable_extentions/declarative_streams.rb
@@ -6,18 +6,12 @@ module Motion
   module ActionCableExtentions
     # Provides a `streaming_from(broadcasts, to:)` API that can be used to
     # declaratively specify what `broadcasts` the channel is interested in
-    # receiving and `to` what method they should be routed. Additionally,
-    # this module extends the "at most one executor at a time" property that
-    # naturally comes with actions to the streams that it sets up as well.
+    # receiving and `to` what method they should be routed.
     module DeclarativeStreams
+      include Synchronization
+
       def initialize(*)
         super
-
-        # Allowing actions to be bound to streams (as this module provides)
-        # introduces the possibiliy of multiple threads accessing user code at
-        # the same time. Protect user code with a Monitor so we only have to
-        # worry about that here.
-        @_declarative_stream_monitor = Monitor.new
 
         # Streams that we are currently interested in
         @_declarative_streams = Set.new
@@ -28,19 +22,6 @@ module Motion
         # Streams that we are setup to listen to. Sadly, there is no public API
         # to stop streaming so this will only grow.
         @_declarative_stream_proxies = Set.new
-      end
-
-      # Synchronize all ActionCable entry points (after initialization).
-      def subscribe_to_channel(*)
-        @_declarative_stream_monitor.synchronize { super }
-      end
-
-      def unsubscribe_from_channel(*)
-        @_declarative_stream_monitor.synchronize { super }
-      end
-
-      def perform_action(*)
-        @_declarative_stream_monitor.synchronize { super }
       end
 
       # Clean up declarative streams when all streams are stopped.
@@ -73,32 +54,17 @@ module Motion
         # TODO: I feel like the fact that we have to specify the coder here is
         # a bug in ActionCable. It should be the default for this karg.
         stream_from(broadcast, coder: ActiveSupport::JSON) do |message|
-          _handle_incoming_broadcast_to_declarative_stream(broadcast, message)
-        rescue Exception => exception # rubocop:disable Lint/RescueException
-          # It is very, very important that we do not allow an exception to
-          # escape here as the internals of ActionCable will stop processing
-          # the broadcast.
-
-          _handle_exception_in_declarative_stream(broadcast, exception)
+          synchronize_entrypoint! do
+            _handle_incoming_broadcast_to_declarative_stream(broadcast, message)
+          end
         end
       end
 
       def _handle_incoming_broadcast_to_declarative_stream(broadcast, message)
-        @_declarative_stream_monitor.synchronize do
-          return unless @_declarative_stream_target &&
-            @_declarative_streams.include?(broadcast)
+        return unless @_declarative_stream_target &&
+          @_declarative_streams.include?(broadcast)
 
-          send(@_declarative_stream_target, broadcast, message)
-        end
-      end
-
-      def _handle_exception_in_declarative_stream(broadcast, exception)
-        logger.error(
-          "There was an exception while handling a broadcast to #{broadcast}" \
-          "on #{self.class}:\n" \
-          "  #{exception.class}: #{exception.message}\n" \
-          "#{exception.backtrace.map { |line| "    #{line}" }.join("\n")}"
-        )
+        send(@_declarative_stream_target, broadcast, message)
       end
     end
   end

--- a/lib/motion/action_cable_extentions/synchronization.rb
+++ b/lib/motion/action_cable_extentions/synchronization.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "motion"
+
+module Motion
+  module ActionCableExtentions
+    module Synchronization
+      def initialize(*)
+        super
+
+        @_monitor = Monitor.new
+      end
+
+      # Additional entrypoints added by other modules should wrap any entry
+      # points that they add with this.
+      def synchronize_entrypoint!(&block)
+        @_monitor.synchronize(&block)
+      end
+
+      # Synchronize all standard ActionCable entry points.
+      def subscribe_to_channel(*)
+        synchronize_entrypoint! { super }
+      end
+
+      def unsubscribe_from_channel(*)
+        synchronize_entrypoint! { super }
+      end
+
+      def perform_action(*)
+        synchronize_entrypoint! { super }
+      end
+    end
+  end
+end

--- a/lib/motion/channel.rb
+++ b/lib/motion/channel.rb
@@ -6,6 +6,7 @@ require "motion"
 
 module Motion
   class Channel < ActionCable::Channel::Base
+    include ActionCableExtentions::DeclarativeNotifications
     include ActionCableExtentions::DeclarativeStreams
     include ActionCableExtentions::LogSuppression
 
@@ -56,10 +57,19 @@ module Motion
       synchronize
     end
 
+    def process_periodic_timer(timer)
+      component_connection.process_periodic_timer(timer)
+      synchronize
+    end
+
     private
 
     def synchronize
-      streaming_from(component_connection.broadcasts, to: :process_broadcast)
+      streaming_from component_connection.broadcasts,
+        to: :process_broadcast
+
+      periodicly_notify component_connection.periodic_timers,
+        via: :process_periodic_timer
 
       component_connection.if_render_required do |component|
         transmit(renderer.render(component))

--- a/lib/motion/channel.rb
+++ b/lib/motion/channel.rb
@@ -68,7 +68,7 @@ module Motion
       streaming_from component_connection.broadcasts,
         to: :process_broadcast
 
-      periodicly_notify component_connection.periodic_timers,
+      periodically_notify component_connection.periodic_timers,
         via: :process_periodic_timer
 
       component_connection.if_render_required do |component|

--- a/lib/motion/component.rb
+++ b/lib/motion/component.rb
@@ -7,6 +7,7 @@ require "motion"
 require "motion/component/broadcasts"
 require "motion/component/lifecycle"
 require "motion/component/motions"
+require "motion/component/periodic_timers"
 require "motion/component/rendering"
 
 module Motion
@@ -16,6 +17,7 @@ module Motion
     include Broadcasts
     include Lifecycle
     include Motions
+    include PeriodicTimers
     include Rendering
   end
 end

--- a/lib/motion/component/periodic_timers.rb
+++ b/lib/motion/component/periodic_timers.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+require "active_support/core_ext/class/attribute"
+require "active_support/core_ext/hash/except"
+
+require "motion"
+
+module Motion
+  module Component
+    module PeriodicTimers
+      extend ActiveSupport::Concern
+
+      # Analogous to `module_function` (available on both class and instance)
+      module ModuleFunctions
+        def every(interval, handler, name: handler)
+          periodic_timer(name, handler, every: interval)
+        end
+
+        def periodic_timer(name, handler = name, every:)
+          self._periodic_timers =
+            _periodic_timers.merge(name.to_s => [handler.to_sym, every]).freeze
+        end
+
+        def stop_periodic_timer(name)
+          self._periodic_timers =
+            _periodic_timers.except(name.to_s).freeze
+        end
+
+        def periodic_timers
+          _periodic_timers.transform_values { |_handler, interval| interval }
+        end
+      end
+
+      included do
+        class_attribute :_periodic_timers,
+          instance_reader: false,
+          instance_writer: false,
+          instance_predicate: false,
+          default: {}.freeze
+      end
+
+      class_methods do
+        include ModuleFunctions
+      end
+
+      include ModuleFunctions
+
+      def process_periodic_timer(name)
+        return unless (handler, _interval = _periodic_timers[name])
+
+        send(handler)
+      end
+
+      private
+
+      attr_writer :_periodic_timers
+
+      def _periodic_timers
+        return @_periodic_timers if defined?(@_periodic_timers)
+
+        self.class._periodic_timers
+      end
+    end
+  end
+end

--- a/lib/motion/component_connection.rb
+++ b/lib/motion/component_connection.rb
@@ -64,6 +64,18 @@ module Motion
       false
     end
 
+    def process_periodic_timer(timer)
+      timing("Proccessed periodic timer #{timer}") do
+        component.process_periodic_timer timer
+      end
+
+      true
+    rescue => error
+      handle_error(error, "processing periodic timer #{timer}")
+
+      false
+    end
+
     def if_render_required(&block)
       timing("Rendered") do
         next_render_hash = component.render_hash
@@ -81,6 +93,10 @@ module Motion
 
     def broadcasts
       component.broadcasts
+    end
+
+    def periodic_timers
+      component.periodic_timers
     end
 
     private

--- a/spec/motion/channel_spec.rb
+++ b/spec/motion/channel_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Motion::Channel, type: :channel do
       it "sets up all of the component's periodic timers" do
         subject
 
-        expect(subscription.declarative_notifications).to(
-          include(*component.periodic_timers.keys)
+        expect(subscription.declarative_notifications.to_a).to(
+          include(*component.periodic_timers)
         )
       end
 
@@ -182,8 +182,8 @@ RSpec.describe Motion::Channel, type: :channel do
     it "sets up all of the component's periodic timers" do
       subject
 
-      expect(subscription.declarative_notifications).to(
-        include(*component.periodic_timers.keys)
+      expect(subscription.declarative_notifications.to_a).to(
+        include(*component.periodic_timers)
       )
     end
 

--- a/spec/motion/channel_spec.rb
+++ b/spec/motion/channel_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Motion::Channel, type: :channel do
         expect(subscription.streams).to include(*component.broadcasts)
       end
 
+      it "sets up all of the component's periodic timers" do
+        subject
+
+        expect(subscription.declarative_notifications).to(
+          include(*component.periodic_timers.keys)
+        )
+      end
+
       it "runs the component's `connected` callback" do
         expect_any_instance_of(TestComponent).to receive(:connected)
         subject
@@ -93,6 +101,19 @@ RSpec.describe Motion::Channel, type: :channel do
       end
     end
 
+    context "with a connected callback that sets up a timer" do
+      let(:component) { TestComponent.new(connected: :setup_dynamic_timer) }
+      it_behaves_like "succesfully mounted", render: true
+
+      it "sets up the new timer" do
+        subject
+
+        expect(subscription.declarative_notifications).to(
+          include(TestComponent::DYNAMIC_TIMER)
+        )
+      end
+    end
+
     context "with a connected callback that raises an error" do
       let(:component) { TestComponent.new(connected: :raise_error) }
       it_behaves_like "failed to mount"
@@ -141,6 +162,11 @@ RSpec.describe Motion::Channel, type: :channel do
       it_behaves_like "dismounted"
     end
 
+    context "with a disconnected callback that sets up a timer" do
+      let(:component) { TestComponent.new(disconnected: :setup_dynamic_timer) }
+      it_behaves_like "dismounted"
+    end
+
     context "with a disconnected callback that raises an error" do
       let(:component) { TestComponent.new(disconnected: :raise_error) }
       it_behaves_like "dismounted"
@@ -151,6 +177,14 @@ RSpec.describe Motion::Channel, type: :channel do
     it "streams from all of the component's broadcasts" do
       subject
       expect(subscription.streams).to include(*component.broadcasts)
+    end
+
+    it "sets up all of the component's periodic timers" do
+      subject
+
+      expect(subscription.declarative_notifications).to(
+        include(*component.periodic_timers.keys)
+      )
     end
 
     if render
@@ -206,6 +240,19 @@ RSpec.describe Motion::Channel, type: :channel do
       end
     end
 
+    context "with a handler that sets up a timer" do
+      let(:motion) { "setup_dynamic_timer" }
+      it_behaves_like "succesfully processed", render: true
+
+      it "sets up the new timer" do
+        subject
+
+        expect(subscription.declarative_notifications).to(
+          include(TestComponent::DYNAMIC_TIMER)
+        )
+      end
+    end
+
     context "with a handler that raises an error" do
       let(:motion) { "raise_error" }
       it_behaves_like "succesfully processed", render: false
@@ -252,8 +299,78 @@ RSpec.describe Motion::Channel, type: :channel do
       end
     end
 
+    context "with a handler that sets up a timer" do
+      let(:stream) { "setup_dynamic_timer" }
+      it_behaves_like "succesfully processed", render: true
+
+      it "sets up the new timer" do
+        subject
+
+        expect(subscription.declarative_notifications).to(
+          include(TestComponent::DYNAMIC_TIMER)
+        )
+      end
+    end
+
     context "with a handler that raises an error" do
       let(:stream) { "raise_error" }
+      it_behaves_like "succesfully processed", render: false
+    end
+  end
+
+  describe "#process_periodic_timer" do
+    subject { subscription.process_periodic_timer(timer) }
+
+    before(:each) { subscribe(state: state, version: version) }
+
+    context "with a handler that does nothing" do
+      let(:timer) { "noop" }
+      it_behaves_like "succesfully processed", render: false
+    end
+
+    context "with a handler that changes state" do
+      let(:timer) { "change_state" }
+      it_behaves_like "succesfully processed", render: true
+    end
+
+    context "with a handler that forces rerender" do
+      let(:timer) { "force_rerender" }
+      it_behaves_like "succesfully processed", render: true
+    end
+
+    context "with a handler that maps a motion" do
+      let(:timer) { "setup_dynamic_motion" }
+      it_behaves_like "succesfully processed", render: true
+    end
+
+    context "with a handler that streams" do
+      let(:timer) { "setup_dynamic_stream" }
+      it_behaves_like "succesfully processed", render: true
+
+      it "sets up the new stream" do
+        subject
+
+        expect(subscription.streams).to(
+          include(TestComponent::DYNAMIC_BROADCAST)
+        )
+      end
+    end
+
+    context "with a handler that sets up a timer" do
+      let(:timer) { "setup_dynamic_timer" }
+      it_behaves_like "succesfully processed", render: true
+
+      it "sets up the new timer" do
+        subject
+
+        expect(subscription.declarative_notifications).to(
+          include(TestComponent::DYNAMIC_TIMER)
+        )
+      end
+    end
+
+    context "with a handler that raises an error" do
+      let(:timer) { "raise_error" }
       it_behaves_like "succesfully processed", render: false
     end
   end

--- a/spec/motion/component/motions_spec.rb
+++ b/spec/motion/component/motions_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe Motion::Component::Motions do
         expect(component.motions).to include(motion)
       end
     end
+
+    describe "#unmap_motion" do
+      subject { component_class.unmap_motion(motion) }
+
+      context "for a mapped motion" do
+        before(:each) { component_class.map_motion(motion, :noop) }
+
+        let(:motion) { SecureRandom.hex }
+
+        it "causes instances of the component not to have that motion" do
+          subject
+          expect(component.motions).not_to include(motion)
+        end
+      end
+    end
   end
 
   subject(:component) { TestComponent.new }
@@ -89,6 +104,18 @@ RSpec.describe Motion::Component::Motions do
 
     it "sets up the motion" do
       expect(component.motions).to include(motion)
+    end
+  end
+
+  describe "#unmap_motion" do
+    subject! { component.unmap_motion(motion) }
+
+    context "for a mapped motion" do
+      let(:motion) { TestComponent::STATIC_MOTIONS.sample }
+
+      it "removes the motion" do
+        expect(component.motions).not_to include(motion)
+      end
     end
   end
 end

--- a/spec/motion/component/periodic_timers_spec.rb
+++ b/spec/motion/component/periodic_timers_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+RSpec.describe Motion::Component::PeriodicTimers do
+  describe described_class::ClassMethods do
+    subject(:component_class) do # We need a fresh class for every spec
+      stub_const("TemporaryComponent", Class.new(ViewComponent::Base) {
+        include Motion::Component
+
+        def noop
+        end
+      })
+    end
+
+    let(:component) { component_class.new }
+
+    describe "#every" do
+      subject! { component_class.every(interval, handler) }
+
+      let(:interval) { rand(1..10) }
+      let(:handler) { :noop }
+
+      it "registers the handler to be invoked at the interval" do
+        expect(component.periodic_timers[handler.to_s]).to eq(interval)
+      end
+    end
+
+    describe "#periodic_timer" do
+      subject! do
+        component_class.periodic_timer(name, handler, every: interval)
+      end
+
+      let(:name) { SecureRandom.hex }
+      let(:interval) { rand(1..10) }
+      let(:handler) { :noop }
+
+      it "sets up a new periodic timer" do
+        expect(component.periodic_timers[name]).to eq(interval)
+      end
+    end
+
+    describe "#stop_periodic_timer" do
+      subject { component_class.stop_periodic_timer(name) }
+
+      context "with a timer that has already been setup" do
+        before(:each) { component_class.periodic_timer(name, :noop, every: 1) }
+
+        let(:name) { SecureRandom.hex }
+
+        it "removes the periodic timer" do
+          subject
+          expect(component.periodic_timers).not_to include(name)
+        end
+      end
+    end
+
+    describe "#periodic_timers" do
+      subject { component_class.periodic_timers }
+
+      it "gives the default periodic timers for the instance" do
+        expect(subject).to eq(component.periodic_timers)
+      end
+    end
+  end
+
+  subject(:component) { TestComponent.new }
+
+  describe "#process_periodic_timer" do
+    subject { component.process_periodic_timer(name) }
+
+    context "with a timer that is registered" do
+      let(:name) { "noop" }
+
+      it "invokes the corresponding handler" do
+        expect(component).to receive(:noop)
+        subject
+      end
+    end
+
+    context "with a timer that is not registered" do
+      let(:name) { SecureRandom.hex }
+
+      it "does not invoke the corresponding handler" do
+        expect(component).not_to receive(name)
+        subject
+      end
+    end
+  end
+
+  describe "#every" do
+    subject! { component.every(interval, handler) }
+
+    let(:interval) { rand(1..10) }
+    let(:handler) { :noop }
+
+    it "registers the handler to be invoked at the interval" do
+      expect(component.periodic_timers[handler.to_s]).to eq(interval)
+    end
+  end
+
+  describe "#periodic_timer" do
+    subject! { component.periodic_timer(name, handler, every: interval) }
+
+    let(:name) { SecureRandom.hex }
+    let(:interval) { rand(1..10) }
+    let(:handler) { :noop }
+
+    it "sets up a new periodic timer" do
+      expect(component.periodic_timers[name]).to eq(interval)
+    end
+  end
+
+  describe "#stop_periodic_timer" do
+    subject! { component.stop_periodic_timer(name) }
+
+    context "with a timer that is registered" do
+      let(:name) { "noop" }
+
+      it "removes the periodic timer" do
+        expect(component.periodic_timers).not_to include(name)
+      end
+    end
+  end
+
+  describe "#periodic_timers" do
+    subject { component.periodic_timers }
+
+    it "gives the periodic timers for the component" do
+      expect(subject.keys).to contain_exactly(*TestComponent::STATIC_TIMERS)
+    end
+  end
+end

--- a/spec/motion/component_connection_spec.rb
+++ b/spec/motion/component_connection_spec.rb
@@ -70,6 +70,38 @@ RSpec.describe Motion::ComponentConnection do
     end
   end
 
+  describe "#process_periodic_timer" do
+    subject { component_connection.process_periodic_timer(timer) }
+
+    before(:each) { component_connection }
+
+    let(:timer) { SecureRandom.hex }
+
+    it "processes the timer callback on the underlying component" do
+      expect_any_instance_of(TestComponent).to(
+        receive(:process_periodic_timer).with(timer)
+      )
+
+      subject
+    end
+
+    it "logs the timing for processing the timer" do
+      expect(Rails.logger).to receive(:info).with(/timer/)
+
+      subject
+    end
+
+    context "when an error occurs while processing the timer" do
+      let(:timer) { "raise_error" }
+
+      it "logs the error and returns false" do
+        expect(Rails.logger).to receive(:error).with(/Error from TestComponent/)
+
+        expect(subject).to be(false)
+      end
+    end
+  end
+
   describe "#if_render_required" do
     subject(:yielded?) do
       yielded = false
@@ -124,6 +156,14 @@ RSpec.describe Motion::ComponentConnection do
 
     it "gives the broadcasts of the underlying component" do
       expect(subject).to eq(component.broadcasts)
+    end
+  end
+
+  describe "#periodic_timers" do
+    subject { component_connection.periodic_timers }
+
+    it "gives the periodic timers of the underlying component" do
+      expect(subject).to eq(component.periodic_timers)
     end
   end
 end

--- a/spec/motion/component_spec.rb
+++ b/spec/motion/component_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe Motion::Component do
   it { is_expected.to include(Motion::Component::Broadcasts) }
   it { is_expected.to include(Motion::Component::Lifecycle) }
   it { is_expected.to include(Motion::Component::Motions) }
+  it { is_expected.to include(Motion::Component::PeriodicTimers) }
   it { is_expected.to include(Motion::Component::Rendering) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
   end
 
   # To avoid running every test twice on subsequent runs because of the
-  # recursive symlink, make sure to unlint the client.
+  # recursive symlink, make sure to unlink the client.
   config.after(:suite) do
     TestApplication.unlink_motion_client!
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,10 +48,16 @@ RSpec.configure do |config|
 
   config.before(:each, type: :system) do
     # Ensure that the client JavaScript within the app is synced with the gem
-    TestApplication.sync_motion_client!
+    TestApplication.link_motion_client!
 
     # Use headless Chrome for system tests
     driven_by :headless_chrome_no_sandbox
+  end
+
+  # To avoid running every test twice on subsequent runs because of the
+  # recursive symlink, make sure to unlint the client.
+  config.after(:suite) do
+    TestApplication.unlink_motion_client!
   end
 
   # For most specs, we want Motion to be configured in a predictable way, but

--- a/spec/support/test_application.rb
+++ b/spec/support/test_application.rb
@@ -8,8 +8,8 @@ TestApplication.load_generators
 
 # Add a helper method to sync the JavaScript in the test app with the outer gem.
 class << TestApplication
-  def sync_motion_client!
-    return if @synced_motion_client
+  def link_motion_client!
+    return if @linked_motion_client
 
     yarn! "--cwd", "../../..", "link"
     yarn! "link", "@unabridged/motion"
@@ -17,7 +17,13 @@ class << TestApplication
 
     clear_webpacker_cache!
 
-    @synced_motion_client = true
+    @linked_motion_client = true
+  end
+
+  def unlink_motion_client!
+    return unless @linked_motion_client
+
+    yarn! "unlink", "@unabridged/motion"
   end
 
   private

--- a/spec/support/test_application/app/components/timer_component.rb
+++ b/spec/support/test_application/app/components/timer_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class TimerComponent < ViewComponent::Base
+  include Motion::Component
+
+  def initialize(seconds: 1)
+    @seconds = seconds
+  end
+
+  every 1.second, :tick
+
+  def tick
+    @seconds -= 1
+
+    stop_periodic_timer(:tick) if @seconds.zero?
+  end
+
+  def call
+    content_tag(:div) { @seconds.to_s }
+  end
+end

--- a/spec/support/test_application/app/controllers/timer_components_controller.rb
+++ b/spec/support/test_application/app/controllers/timer_components_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TimerComponentsController < ApplicationController
+  def show
+    render_component_in_layout(TimerComponent.new)
+  end
+end

--- a/spec/support/test_application/config/routes.rb
+++ b/spec/support/test_application/config/routes.rb
@@ -2,6 +2,7 @@
 
 Rails.application.routes.draw do
   resource :counter_component, only: :show
+  resource :timer_component, only: :show
   resource :test_component, only: :show
 
   resources :dogs, only: [:new, :create]

--- a/spec/support/test_component.rb
+++ b/spec/support/test_component.rb
@@ -15,8 +15,8 @@ class TestComponent < ViewComponent::Base
     force_rerender
     setup_dynamic_motion
     setup_dynamic_stream
+    setup_dynamic_timer
     raise_error
-    raise_exception
   ].freeze
 
   # used by tests that want to know the initial broadcasts
@@ -28,8 +28,19 @@ class TestComponent < ViewComponent::Base
     force_rerender
     setup_dynamic_motion
     setup_dynamic_stream
+    setup_dynamic_timer
     raise_error
-    raise_exception
+  ].freeze
+
+  # used by tests that want to know the initial timers
+  STATIC_TIMERS = %w[
+    noop
+    change_state
+    force_rerender
+    setup_dynamic_motion
+    setup_dynamic_stream
+    setup_dynamic_timer
+    raise_error
   ].freeze
 
   attr_reader :count
@@ -66,6 +77,7 @@ class TestComponent < ViewComponent::Base
 
   stream_from "noop", :noop
   map_motion :noop
+  every 10_000.years, :noop
 
   def noop(*)
   end
@@ -84,6 +96,7 @@ class TestComponent < ViewComponent::Base
 
   stream_from "change_state", :change_state
   map_motion :change_state
+  every 10_000.years, :change_state
 
   def change_state(*)
     @count += 1
@@ -91,6 +104,7 @@ class TestComponent < ViewComponent::Base
 
   stream_from "force_rerender", :force_rerender
   map_motion :force_rerender
+  every 10_000.years, :force_rerender
 
   def force_rerender(*)
     rerender!
@@ -98,6 +112,7 @@ class TestComponent < ViewComponent::Base
 
   stream_from "setup_dynamic_motion", :setup_dynamic_motion
   map_motion :setup_dynamic_motion
+  every 10_000.years, :setup_dynamic_motion
 
   # used for tests that want to detect this dynamic motion being setup
   DYNAMIC_MOTION = "dynamic_motion"
@@ -108,6 +123,7 @@ class TestComponent < ViewComponent::Base
 
   stream_from "setup_dynamic_stream", :setup_dynamic_stream
   map_motion :setup_dynamic_stream
+  every 10_000.years, :setup_dynamic_stream
 
   # used for tests that want to detect this dynamic broadcast being setup
   DYNAMIC_BROADCAST = "dynamic_broadcast"
@@ -116,18 +132,22 @@ class TestComponent < ViewComponent::Base
     stream_from DYNAMIC_BROADCAST, :noop
   end
 
+  stream_from "setup_dynamic_timer", :setup_dynamic_timer
+  map_motion :setup_dynamic_timer
+  every 10_000.years, :setup_dynamic_timer
+
+  # used for tests that want to detect this dynamic timer being setup
+  DYNAMIC_TIMER = "dynamic_timer"
+
+  def setup_dynamic_timer(*)
+    periodic_timer DYNAMIC_TIMER, :noop, every: 10_000.years
+  end
+
   stream_from "raise_error", :raise_error
   map_motion :raise_error
+  every 10_000.years, :raise_error
 
   def raise_error(*)
     raise "Error from TestComponent"
-  end
-
-  stream_from "raise_exception", :raise_exception
-  map_motion :raise_exception
-
-  def raise_exception(*)
-    raise Exception, # rubocop:disable Lint/RaiseException
-      "Exception from TestComponent"
   end
 end

--- a/spec/system/core_functionality_spec.rb
+++ b/spec/system/core_functionality_spec.rb
@@ -21,21 +21,6 @@ RSpec.describe "Core Functionality", type: :system do
     expect(page).to have_text("The state has been changed 1 times.")
   end
 
-  scenario "A catastrophic error in the component does not break the app" do
-    visit(test_component_path)
-
-    expect(page).to have_text("The state has been changed 0 times.")
-
-    expect(Rails.logger).to(
-      receive(:error).with(/Exception from TestComponent/)
-    )
-
-    expect { ActionCable.server.broadcast "raise_exception", "message" }
-      .not_to(raise_exception)
-
-    expect(page).to have_text("The state has been changed 0 times.")
-  end
-
   scenario "Nested state is preserved when an outer component renders" do
     visit(counter_component_path)
 
@@ -70,5 +55,15 @@ RSpec.describe "Core Functionality", type: :system do
 
     expect(find(".parent .count")).to have_text("3")
     expect(find(".child .count")).to have_text("3")
+  end
+
+  scenario "Periodic timers run and can be removed dynamically" do
+    visit(timer_component_path)
+
+    expect(page).to have_text("1")
+    sleep 1
+    expect(page).to have_text("0")
+    sleep 1
+    expect(page).to have_text("0")
   end
 end


### PR DESCRIPTION
This PR got a little out of control (:see_no_evil:), but it can be reviewed by commit.

It adds a new periodic timer API to components:
```ruby
class CountdownComponent < ViewComponent::Base
  include Motion::Component

  attr_reader :count

  def initialize(count: 10)
    @count = count
  end

  def call
    content_tag(:div) { "The count is #{count}." }
  end

  # This is sugar for `periodic_timer :tick, every: 1.second`.
  every 1.second, :tick

  def tick
    @count -= 1

    stop_periodic_timer :tick if count.zero?
  end
end
```

(Also, the testing here is minimal, but I intent to build it up more over time)