### PR TITLE
Allow TEXTAREAs to be updated

### DIFF
--- a/javascript/reconcile.js
+++ b/javascript/reconcile.js
@@ -24,11 +24,18 @@ export default (rootElement, newState, keyAttribute) => {
       return false
     }
 
-    // When two nodes have (deep) DOM equality, don't replace. This is correct
-    // because we checked above that we are reconsiling against an HTML string
-    // (which cannot possibly have state outside of the DOM because no handles
-    // have been allowed to leave this function since parsing).
-    if (fromElement.isEqualNode(toElement)) {
+    if (
+      // For some reason, it it seems like all TEXTAREAs are equal to eachother
+      // regardless of their content which is super werid because the same thing
+      // does not seem to be true for INPUTs or SELECTs whose value has changed.
+      fromElement.tagName !== 'TEXTAREA' &&
+
+      // When two nodes have (deep) DOM equality, don't replace. This is correct
+      // because we checked above that we are reconsiling against an HTML string
+      // (which cannot possibly have state outside of the DOM because no handles
+      // have been allowed to leave this function since parsing).
+      fromElement.isEqualNode(toElement)
+    ) {
       return false
     }
 


### PR DESCRIPTION
This fixes a bug noticed by Kyle while building his demo.

It seems that all `TEXTAREA`s are considered deeply equal (`isEqualNode`) by the DOM regardless of their value. This is very strange because the same thing is _not_ true for `input` or `select`. In fact, it is _so_ strange that it is easier for me to believe that there is something wrong with my understanding of the situation (or perhaps a bug in `morphdom`) than this is everything working as intended.

Regardless, adding this special case remedies the immediate issue in Kyle's demo.

If more of these special cases arise, it might be worth [taking the performance hit](https://github.com/patrick-steele-idem/morphdom#can-i-make-morphdom-blaze-through-the-dom-tree-even-faster-yes) and using `morphdom`'s native diffing which _does_ also fix the issue.