### PR TITLE
Add revision class to calculate revision hash

### DIFF
--- a/lib/generators/motion/templates/motion.rb
+++ b/lib/generators/motion/templates/motion.rb
@@ -5,12 +5,12 @@ Motion.configure do |config|
   # version of your application. By default, the commit hash from git is used,
   # but depending on your deployment, this may not be available in production.
   #
-  # If you are sure that git is available in your production enviorment, you can
+  # If you are sure that git is available in your production environment, you can
   # uncomment this line:
   #
   #     config.revision = `git rev-parse HEAD`.chomp
   #
-  # If git is not available in your production enviorment, you must identify
+  # If git is not available in your production environment, you must identify
   # your application version some other way:
   #
   #     config.revision =

--- a/lib/generators/motion/templates/motion.rb
+++ b/lib/generators/motion/templates/motion.rb
@@ -5,13 +5,16 @@ Motion.configure do |config|
   # version of your application. By default, the commit hash from git is used,
   # but depending on your deployment, this may not be available in production.
   #
-  # If you are sure that git is available in your production environment, you can
-  # uncomment this line:
+  # Motion automatically calculates your revision by hashing the contents of
+  # files in `revision_paths` The defaults revision paths are:
+  # rails paths, bin, and Gemfile.lock.
   #
-  #     config.revision = `git rev-parse HEAD`.chomp
+  # To change or add to your revision paths, uncomment this line:
   #
-  # If git is not available in your production environment, you must identify
-  # your application version some other way:
+  #     config.revision_paths += w(additional_path another_path)
+  #
+  # If you prefer to use git or an environmental variable for the revision
+  # in production, define the revision directly below.
   #
   #     config.revision =
   #       ENV.fetch("MY_DEPLOYMENT_NUMBER") { `git rev-parse HEAD`.chomp }

--- a/lib/motion.rb
+++ b/lib/motion.rb
@@ -14,6 +14,7 @@ module Motion
   autoload :LogHelper, "motion/log_helper"
   autoload :MarkupTransformer, "motion/markup_transformer"
   autoload :Railtie, "motion/railtie"
+  autoload :RevisionCalculator, "motion/revision_calculator"
   autoload :Serializer, "motion/serializer"
   autoload :TestHelpers, "motion/test_helpers"
 

--- a/lib/motion/configuration.rb
+++ b/lib/motion/configuration.rb
@@ -62,11 +62,14 @@ module Motion
     option :revision_paths do
       require "rails"
 
-      paths
+      Rails.application.config.paths.dup.tap do |paths|
+        paths.add "bin", glob: "*"
+        paths.add "Gemfile.lock"
+      end
     end
 
     option :revision do
-      RevisionCalculator.new(revision_paths: @revision_paths).perform
+      RevisionCalculator.new(revision_paths: revision_paths).perform
     end
 
     option :renderer_for_connection_proc do
@@ -99,17 +102,5 @@ module Motion
     # This is included for completeness. It is not currently used internally by
     # Motion, but it might be required for building view helpers in the future.
     option(:motion_attribute) { "data-motion" }
-
-    def paths
-      @paths ||= begin
-        paths = Rails.application.config.paths.dup
-
-        paths.add "bin", glob: "*"
-
-        paths.add "Gemfile.lock"
-
-        paths
-      end
-    end
   end
 end

--- a/lib/motion/configuration.rb
+++ b/lib/motion/configuration.rb
@@ -66,20 +66,6 @@ module Motion
     end
 
     option :revision do
-      warn <<~MSG
-        Motion is automatically inferring the application's revision by
-        calculating the content of files in motion_config.revision_paths.
-        The defaults revision paths are: Rails paths, bin, and the Gemfile.lock.
-
-        You can add paths to the revision_path using the `revision_paths` option.
-
-        If you prefer to use git for the revision in production,
-        add "config.revision = `git rev-parse HEAD`.chomp" to your
-        Motion initializer.
-
-        Other options might include an environmental variable.
-      MSG
-
       RevisionCalculator.new(revision_paths: @revision_paths).perform
     end
 

--- a/lib/motion/errors.rb
+++ b/lib/motion/errors.rb
@@ -148,4 +148,14 @@ module Motion
       super("The revision cannot contain a NULL byte")
     end
   end
+
+  class BadRevisionPathsError < Error
+    def initialize
+      super(<<~MSG)
+        Revision paths must be a Rails::Paths::Root object or an object
+        that responds to `all_paths.flat_map(&:existent)` and returns an
+        Array of strings representing paths relative to root.
+      MSG
+    end
+  end
 end

--- a/lib/motion/errors.rb
+++ b/lib/motion/errors.rb
@@ -154,7 +154,7 @@ module Motion
       super(<<~MSG)
         Revision paths must be a Rails::Paths::Root object or an object
         that responds to `all_paths.flat_map(&:existent)` and returns an
-        Array of strings representing paths relative to root.
+        Array of strings representing full paths.
       MSG
     end
   end

--- a/lib/motion/revision_calculator.rb
+++ b/lib/motion/revision_calculator.rb
@@ -21,6 +21,7 @@ module Motion
       digest = Digest::MD5.new
 
       files.each do |file|
+        digest << file # include filename as well as contents
         digest << File.read(file)
       end
 
@@ -41,7 +42,7 @@ module Motion
     end
 
     def files
-      @files ||= existent_paths.flat_map { |path| existent_files(path) }
+      @files ||= existent_paths.flat_map { |path| existent_files(path) }.sort
     end
   end
 end

--- a/lib/motion/revision_calculator.rb
+++ b/lib/motion/revision_calculator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "digest"
+require "motion"
+
+module Motion
+  class RevisionCalculator
+    attr_reader :revision_paths
+
+    def initialize(revision_paths:)
+      @revision_paths = revision_paths
+    end
+
+    def perform
+      derive_md5_hash
+    end
+
+    private
+
+    def file_contents
+      files.map { |f| File.read(f) }.join
+    end
+
+    def existent_paths
+      @existent_paths ||= revision_paths.all_paths.flat_map(&:existent)
+    end
+
+    def files
+      @files ||= existent_paths.flat_map { |path| Dir["#{path}/**/*", path].reject { |f| File.directory?(f) } }.uniq
+    end
+
+    def derive_md5_hash
+      Digest::MD5.hexdigest(file_contents)
+    end
+  end
+end

--- a/lib/motion/revision_calculator.rb
+++ b/lib/motion/revision_calculator.rb
@@ -17,10 +17,6 @@ module Motion
 
     private
 
-    def file_contents
-      files.map { |f| File.read(f) }.join
-    end
-
     def existent_paths
       @existent_paths ||= revision_paths.all_paths.flat_map(&:existent)
     end
@@ -30,7 +26,13 @@ module Motion
     end
 
     def derive_md5_hash
-      Digest::MD5.hexdigest(file_contents)
+      digest = Digest::MD5.new
+
+      files.each do |file|
+        digest << File.read(file)
+      end
+
+      digest.hexdigest
     end
   end
 end

--- a/spec/motion/configuration_spec.rb
+++ b/spec/motion/configuration_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Motion::Configuration do
     end
   end
 
-  it "allows options to be set within the initalization block" do
+  it "allows options to be set within the initialization block" do
     config =
       described_class.new { |c|
         c.revision = "value"
@@ -109,7 +109,7 @@ RSpec.describe Motion::Configuration do
     expect(config.revision).to eq("value")
   end
 
-  it "does not allow options to be set after initalization" do
+  it "does not allow options to be set after initialization" do
     config =
       described_class.new { |c|
         c.revision = "value"

--- a/spec/motion/configuration_spec.rb
+++ b/spec/motion/configuration_spec.rb
@@ -5,16 +5,12 @@ RSpec.describe Motion::Configuration do
     subject(:default) { described_class.new }
 
     before(:each) do
-      expect_any_instance_of(described_class).to(
-        receive(:warn).with(/Motion is automatically inferring/)
-      )
-
-      expect_any_instance_of(described_class).to(
-        receive(:`).with("git rev-parse HEAD").and_return(revision_from_git)
+      expect_any_instance_of(Motion::RevisionCalculator).to(
+        receive(:perform).and_return(revision_hash)
       )
     end
 
-    let(:revision_from_git) { "revision-hash" }
+    let(:revision_hash) { "revision-hash" }
 
     describe "#secret" do
       subject { default.secret }
@@ -29,7 +25,18 @@ RSpec.describe Motion::Configuration do
     describe "#revision" do
       subject { default.revision }
 
-      it { is_expected.to eq(revision_from_git) }
+      it { is_expected.to eq(revision_hash) }
+    end
+
+    describe "#revision_paths" do
+      subject { default.revision_paths }
+      let(:rails_path_keys) { Rails.application.config.paths.keys }
+      let(:additional_paths) { %w[bin Gemfile.lock] }
+      let(:revision_path_keys) { subject.keys }
+
+      it { is_expected.to be_a_kind_of(Rails::Paths::Root) }
+      it { expect(revision_path_keys).to include(*rails_path_keys) }
+      it { expect(revision_path_keys).to include(*additional_paths) }
     end
 
     describe "#renderer_for_connection_proc" do

--- a/spec/motion/configuration_spec.rb
+++ b/spec/motion/configuration_spec.rb
@@ -4,14 +4,6 @@ RSpec.describe Motion::Configuration do
   describe "the default configuration" do
     subject(:default) { described_class.new }
 
-    before(:each) do
-      expect_any_instance_of(Motion::RevisionCalculator).to(
-        receive(:perform).and_return(revision_hash)
-      )
-    end
-
-    let(:revision_hash) { "revision-hash" }
-
     describe "#secret" do
       subject { default.secret }
 
@@ -23,6 +15,14 @@ RSpec.describe Motion::Configuration do
     end
 
     describe "#revision" do
+      let(:revision_hash) { "revision-hash" }
+
+      before(:each) do
+        expect_any_instance_of(Motion::RevisionCalculator).to(
+          receive(:perform).and_return(revision_hash)
+        )
+      end
+
       subject { default.revision }
 
       it { is_expected.to eq(revision_hash) }

--- a/spec/motion/revision_calculator_spec.rb
+++ b/spec/motion/revision_calculator_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Motion::RevisionCalculator do
+  subject(:calculator) do
+    described_class.new(
+      revision_paths: revision_paths
+    )
+  end
+
+  let(:revision_paths) { Rails.application.config.paths.dup }
+
+  describe "#perform" do
+    subject(:output) { calculator.perform }
+    let(:empty_hash) { Digest::MD5.new.hexdigest }
+
+    context "when the revisions path is not a Rails::Paths::Root object" do
+      let(:revision_paths) { [] }
+
+      it "raises BadRevisionPathsError" do
+        expect { subject }.to raise_error(Motion::BadRevisionPathsError)
+      end
+    end
+
+    context "when there are no paths to hash" do
+      let(:revision_paths) { Rails::Paths::Root.new(Rails.application.root) }
+      let(:empty_hash) { Digest::MD5.new.hexdigest }
+
+      it "hashes empty digest" do
+        expect(subject).to eq(empty_hash)
+      end
+    end
+
+    context "when paths do not exist" do
+      let(:revision_paths) do
+        paths = Rails::Paths::Root.new(Rails.application.root)
+        paths.add "foo"
+        paths
+      end
+
+      it "ignores empty directory" do
+        expect(subject).to eq(empty_hash)
+      end
+    end
+
+    context "for normal application with files" do
+      let(:all_dirs) { revision_paths.all_paths.flat_map(&:existent) }
+      let(:first_dir) { all_dirs.first }
+      let(:new_file) { "#{first_dir}/foot.txt" }
+
+      before(:each) { File.delete(new_file) if File.exist?(new_file) }
+      after(:each) { File.delete(new_file) if File.exist?(new_file) }
+
+      it "hashes contents" do
+        expect(subject).not_to eq(empty_hash)
+      end
+
+      it "has files to hash" do
+        assert all_dirs.length.positive?
+      end
+
+      it "changes contents when file contents change" do
+        first_result = subject
+
+        File.open(new_file, "w+") { |file| file.write("test") }
+        second_calc = Motion::RevisionCalculator.new(revision_paths: revision_paths).perform
+        expect(second_calc).not_to eq(first_result)
+        expect(second_calc).not_to eq(empty_hash)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,13 +62,7 @@ RSpec.configure do |config|
 
     Motion.reset_internal_state_for_testing!
 
-    RSpec::Mocks.with_temporary_scope do
-      # Motion will whine about not being configured. This is expected and does
-      # not need to clutter up the output while running these examples.
-      allow_any_instance_of(Motion::Configuration).to receive(:warn)
-
-      example.run
-    end
+    example.run
 
     Motion.reset_internal_state_for_testing!(testing_configuration)
   end


### PR DESCRIPTION
# Description

Hash contents of files instead of using git to determine the revision.

This gives support to production environments that might not have git.

Revision paths can be adjusted in motion's config.  Defaults are Rails paths + Gemfile.lock + bin.