### PR TITLE
Use click as default event for input[type=submit]

### DIFF
--- a/javascript/BindingManager.js
+++ b/javascript/BindingManager.js
@@ -41,11 +41,10 @@ export default class BindingManager {
 
   parseBindings () {
     const { motionAttribute } = this.client
-    const { tagName } = this.element
     const bindingsString = this.element.getAttribute(motionAttribute)
     const bindings = new Map()
 
-    for (const binding of parseBindings(bindingsString, tagName)) {
+    for (const binding of parseBindings(bindingsString, this.element)) {
       bindings.set(binding.id, binding)
     }
 

--- a/javascript/parseBindings.js
+++ b/javascript/parseBindings.js
@@ -16,7 +16,7 @@ const DEFAULT_EVENT = {
   _other: 'click',
 
   FORM: 'submit',
-  INPUT: 'change',
+  INPUT: ({ type }) => type === 'submit' ? 'click' : 'change',
   SELECT: 'change',
   TEXTAREA: 'change'
 }
@@ -26,7 +26,7 @@ const DEFAULT_MODE = {
   change: MODE_LISTEN
 }
 
-export default function parseBindings (input, tagName = '_other') {
+export default function parseBindings (input, element) {
   if (!input) {
     return []
   }
@@ -37,13 +37,11 @@ export default function parseBindings (input, tagName = '_other') {
 
     const event =
       match[captureIndicies.event] ||
-      DEFAULT_EVENT[tagName] ||
-      DEFAULT_EVENT._other
+      defaultEventFor(element)
 
     const mode =
       match[captureIndicies.mode] ||
-      DEFAULT_MODE[event] ||
-      DEFAULT_MODE._other
+      defaultModeFor(event)
 
     return {
       id,
@@ -52,4 +50,20 @@ export default function parseBindings (input, tagName = '_other') {
       mode
     }
   })
+}
+
+function defaultEventFor (element) {
+  const event =
+    DEFAULT_EVENT[element && element.tagName] ||
+    DEFAULT_EVENT._other
+
+  if (typeof (event) === 'function') {
+    return event(element)
+  } else {
+    return event
+  }
+}
+
+function defaultModeFor (event) {
+  return DEFAULT_MODE[event] || DEFAULT_MODE._other
 }

--- a/spec/javascript/parseBindings.js
+++ b/spec/javascript/parseBindings.js
@@ -44,10 +44,10 @@ describe('parseBindings', () => {
     })
 
     context('on a form', () => {
-      const tagName = 'FORM'
+      const element = document.createElement('FORM')
 
       it('gives the correct parsing', () => {
-        expect(parseBindings(input, tagName)).to.eql([
+        expect(parseBindings(input, element)).to.eql([
           {
             id: 'sing',
             event: 'submit',
@@ -71,14 +71,42 @@ describe('parseBindings', () => {
     })
 
     context('on an input', () => {
-      const tagName = 'INPUT'
+      const element = document.createElement('INPUT')
 
       it('gives the correct parsing', () => {
-        expect(parseBindings(input, tagName)).to.eql([
+        expect(parseBindings(input, element)).to.eql([
           {
             id: 'sing',
             event: 'change',
             mode: 'listen',
+            motion: 'sing'
+          },
+          {
+            id: 'song:finished->dance',
+            event: 'song:finished',
+            mode: 'handle',
+            motion: 'dance'
+          },
+          {
+            id: 'click(listen)->backflip',
+            event: 'click',
+            mode: 'listen',
+            motion: 'backflip'
+          }
+        ])
+      })
+    })
+
+    context('on an input[type=submit]', () => {
+      const element = document.createElement('INPUT')
+      element.setAttribute('type', 'submit')
+
+      it('gives the correct parsing', () => {
+        expect(parseBindings(input, element)).to.eql([
+          {
+            id: 'sing',
+            event: 'click',
+            mode: 'handle',
             motion: 'sing'
           },
           {


### PR DESCRIPTION
This fixes the final issue noticed by Kyle while building his demo.

In general, we want inputs to default to `change`, but `input[type=submit]` is a special case since it is a button.