### PR TITLE
Add support for accessing the currentTarget

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,16 @@ Methods that are mapped using `map_motion` accept an `event` parameter which is 
     event.type # => "change"
     event.name # alias for type
 
-    element = event.element # => Motion::Element instance (the element with the `data-motion` attribute)
+    # Motion::Element instance, the element that received the event.
+    event.target
+
+    # Motion::Element instance, the element with the event handler and the `data-motion` attribute
+    element = event.current_target
+    # Alias for #current_target
+    event.element
+
+
+    # Element API examples
     element.tag_name # => "input"
     element.value # => "5"
     element.attributes # { class: "col-xs-12", ... }

--- a/README.md
+++ b/README.md
@@ -151,14 +151,16 @@ Methods that are mapped using `map_motion` accept an `event` parameter which is 
     event.type # => "change"
     event.name # alias for type
 
-    element = event.target # => Motion::Element instance
+    element = event.element # => Motion::Element instance (the element with the `data-motion` attribute)
     element.tag_name # => "input"
     element.value # => "5"
-    element[:value] # hash lookup version, works for all attributes
     element.attributes # { class: "col-xs-12", ... }
 
-    # DOM element with data-field="..."
-    element.data[:field]
+    # DOM element with aria-label="..."
+    element[:aria_label]
+
+    # DOM element with data-extra-info="..."
+    element.data[:extra_info]
 
     # ActionController::Parameters instance with all form params. Also
     # available on Motion::Event objects for convenience.

--- a/javascript/serializeEvent.js
+++ b/javascript/serializeEvent.js
@@ -2,12 +2,14 @@ export default function serializeEvent (event, extraData = null) {
   const { type } = event
   const details = serializeEventDetails(event)
   const target = serializeElement(event.target)
+  const currentTarget = serializeElement(event.currentTarget)
 
   return {
     type,
     details,
     extraData,
-    target
+    target,
+    currentTarget
   }
 };
 

--- a/lib/motion/event.rb
+++ b/lib/motion/event.rb
@@ -34,8 +34,16 @@ module Motion
       @target = Motion::Element.from_raw(raw["target"])
     end
 
+    def current_target
+      return @current_target if defined?(@current_target)
+
+      @current_target = Motion::Element.from_raw(raw["currentTarget"])
+    end
+
+    alias element current_target
+
     def form_data
-      target&.form_data
+      element&.form_data
     end
   end
 end

--- a/spec/motion/event_spec.rb
+++ b/spec/motion/event_spec.rb
@@ -32,19 +32,30 @@ RSpec.describe Motion::Event do
           "y" => "7"
         },
         "extraData" => nil,
-        "target" =>
-         {
-           "tagName" => "INPUT",
-           "value" => "test",
-           "attributes" => {
-             "class" => "form-control",
-             "data-field" => "name",
-             "type" => "text",
-             "name" => "sign_up[name]",
-             "id" => "sign_up_name"
-           },
-           "formData" => "sign_up%5Bname%5D=test"
-         }
+        "target" => {
+          "tagName" => "INPUT",
+          "value" => "test",
+          "attributes" => {
+            "class" => "form-control",
+            "data-field" => "name",
+            "type" => "text",
+            "name" => "sign_up[name]",
+            "id" => "sign_up_name"
+          },
+          "formData" => "sign_up%5Bname%5D=test"
+        },
+        "currentTarget" => {
+          "tagName" => "INPUT",
+          "value" => "test",
+          "attributes" => {
+            "class" => "form-control",
+            "data-field" => "name",
+            "type" => "text",
+            "name" => "sign_up[name]",
+            "id" => "sign_up_name"
+          },
+          "formData" => "sign_up%5Bname%5D=test"
+        }
       }
     end
 
@@ -79,6 +90,16 @@ RSpec.describe Motion::Event do
 
       it "has raw data from the underlying event" do
         expect(subject.raw).to eq(raw["target"])
+      end
+    end
+
+    describe "#current_target" do
+      subject { event.current_target }
+
+      it { is_expected.to be_a(Motion::Element) }
+
+      it "has raw data from the underlying event" do
+        expect(subject.raw).to eq(raw["currentTarget"])
       end
     end
 


### PR DESCRIPTION
This adds the ability to access the [`currentTarget`](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget) of events. Since, in Motion, this is the element to which the developer added the `data-motion` attribute, it is aliased to `element` to make it clear that it is usually the correct "default" choice.

One annoying detail of this implementation is that it means in a lot of cases we will probably include two copies of the same form data. I don't think this is a huge concern though.