### PR TITLE
Replace nested components when outer state changes

### DIFF
--- a/javascript/BindingManager.js
+++ b/javascript/BindingManager.js
@@ -11,24 +11,10 @@ export default class BindingManager {
   }
 
   update () {
-    const bindings = this.parseBindings()
+    const targetBindings = this.parseBindings()
 
-    for (const [id, [event, callback]] of this._handlers.entries()) {
-      if (!bindings.has(id)) {
-        this.element.removeEventListener(event, callback)
-        this._handlers.delete(id)
-      }
-    }
-
-    for (const [id, binding] of bindings.entries()) {
-      if (!this._handlers.has(id)) {
-        const { event } = binding
-        const handler = this._buildHandlerForBinding(binding)
-
-        this.element.addEventListener(event, handler)
-        this._handlers.set(id, [event, handler])
-      }
-    }
+    this._removeExtraHandlers(targetBindings)
+    this._setupMissingHandlers(targetBindings)
   }
 
   shutdown () {
@@ -61,6 +47,27 @@ export default class BindingManager {
         if (mode === MODE_HANDLE) {
           event.preventDefault()
         }
+      }
+    }
+  }
+
+  _setupMissingHandlers (targetBindings) {
+    for (const [id, binding] of targetBindings.entries()) {
+      if (!this._handlers.has(id)) {
+        const { event } = binding
+        const handler = this._buildHandlerForBinding(binding)
+
+        this.element.addEventListener(event, handler)
+        this._handlers.set(id, [event, handler])
+      }
+    }
+  }
+
+  _removeExtraHandlers (targetBindings) {
+    for (const [id, [event, callback]] of this._handlers.entries()) {
+      if (!targetBindings.has(id)) {
+        this.element.removeEventListener(event, callback)
+        this._handlers.delete(id)
       }
     }
   }

--- a/javascript/Client.js
+++ b/javascript/Client.js
@@ -8,11 +8,12 @@ export default class Client {
   constructor (options = {}) {
     Object.assign(this, Client.defaultOptions, options)
 
-    this._componentSelector = `[${this.stateAttribute}]`
+    this._componentSelector = `[${this.keyAttribute}][${this.stateAttribute}]`
 
     this._componentTracker =
-      new AttributeTracker(this.stateAttribute, (element) => (
-        new Component(this, element)
+      new AttributeTracker(this.keyAttribute, (element) => (
+        element.hasAttribute(this.stateAttribute) // ensure matches selector
+          ? new Component(this, element) : null
       ))
 
     this._motionTracker =
@@ -27,6 +28,12 @@ export default class Client {
 
     if (this.shutdownBeforeUnload) {
       beforeDocumentUnload.then(() => this.shutdown())
+    }
+  }
+
+  log (...args) {
+    if (this.logging) {
+      console.log('[Motion]', ...args)
     }
   }
 
@@ -47,16 +54,14 @@ Client.defaultOptions = {
     return getFallbackConsumer()
   },
 
-  get root () {
-    return document
-  },
-
   getExtraDataForEvent (_event) {
     // noop
   },
 
-  shutdownBeforeUnload: true,
   logging: false,
+
+  root: document,
+  shutdownBeforeUnload: true,
 
   keyAttribute: 'data-motion-key',
   stateAttribute: 'data-motion-state',

--- a/javascript/Component.js
+++ b/javascript/Component.js
@@ -27,17 +27,12 @@ export default class Component {
   }
 
   processMotion (name, event = null) {
-    if (this.client.logging) {
-      console.log('Processing motion', name, 'on', this.element)
-    }
-
     if (!this._subscription) {
-      if (this.client.logging) {
-        console.log('Dropped motion', name, 'on', this.element)
-      }
-
+      this.client.log('Dropped motion', name, 'on', this.element)
       return
     }
+
+    this.client.log('Processing motion', name, 'on', this.element)
 
     const extraDataForEvent = event && this.client.getExtraDataForEvent(event)
 
@@ -58,33 +53,25 @@ export default class Component {
   }
 
   _beforeConnect () {
-    if (this.client.logging) {
-      console.log('Connecting component', this.element)
-    }
+    this.client.log('Connecting component', this.element)
 
     dispatchEvent(this.element, 'motion:before-connect')
   }
 
   _connect () {
-    if (this.client.logging) {
-      console.log('Component connected', this.element)
-    }
+    this.client.log('Component connected', this.element)
 
     dispatchEvent(this.element, 'motion:connect')
   }
 
   _connectFailed () {
-    if (this.client.logging) {
-      console.log('Failed to connect component', this.element)
-    }
+    this.client.log('Failed to connect component', this.element)
 
     dispatchEvent(this.element, 'motion:connect-failed')
   }
 
   _disconnect () {
-    if (this.client.logging) {
-      console.log('Component disconnected', this.element)
-    }
+    this.client.log('Component disconnected', this.element)
 
     dispatchEvent(this.element, 'motion:disconnect')
   }
@@ -94,9 +81,7 @@ export default class Component {
 
     reconcile(this.element, newState, this.client.keyAttribute)
 
-    if (this.client.logging) {
-      console.log('Component rendered', this.element)
-    }
+    this.client.log('Component rendered', this.element)
 
     dispatchEvent(this.element, 'motion:render')
   }


### PR DESCRIPTION
This fixes the strange flickering behaviour seen in Lexie's demo (although I suspect in a way that she will find disapointing).

This is a regression likely introduced by the switch away from Stimulus. I've opted to restore the original functionality here: When an outer component asserts a _new outer state_, the inner component is replaced.

That is, given some markup like:
```erb
<%= render NestedComponent.new(state_from_outer: @state) %>
```

Re-rendering the outer component where `@state` does _not_ change, will preserve the inner state of `NestedComponent`. However, asserting a new outer state by changing `@state` will cause the state of `NestedComponent` to be reset.

Fascinatingly though, in the process of refactoring to fix this issue and clarifying my own thinking about the relationship between key and state, I have realized how we might be able to support something like React's old `componentWillReceiveProps` if there is interest (To be clear, that is _not_ implemented here though).