### PR TITLE
Less wasteful render_hash

### DIFF
--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -24,16 +24,7 @@ module Motion
       # * If it doesn't change every time the component's state changes,
       #   things may fall out of sync unless you also call `#rerender!`
       def render_hash
-        # TODO: This implementation is trivially correct, but very wasteful.
-        #
-        # Is something with Ruby's built-in `hash` Good Enough(TM)?
-        #
-        #  instance_variables
-        #    .map { |ivar| instance_variable_get(ivar).hash }
-        #    .reduce(0, &:^)
-
-        key, _state = Motion.serializer.serialize(self)
-        key
+        Motion.serializer.weak_digest(self)
       end
 
       def render_in(view_context)

--- a/lib/motion/serializer.rb
+++ b/lib/motion/serializer.rb
@@ -32,6 +32,10 @@ module Motion
       @revision = revision
     end
 
+    def weak_digest(component)
+      dump(component).hash
+    end
+
     def serialize(component)
       state = dump(component)
       state_with_revision = "#{revision}#{NULL_BYTE}#{state}"

--- a/spec/motion/serializer_spec.rb
+++ b/spec/motion/serializer_spec.rb
@@ -27,6 +27,40 @@ RSpec.describe Motion::Serializer do
     end
   end
 
+  describe "#weak_digest" do
+    subject(:weak_digest) { serializer.weak_digest(object) }
+
+    context "when the object can be serialized" do
+      let(:object) { [data] }
+      let(:data) { SecureRandom.hex }
+
+      let(:other_object_with_same_state) { [data] }
+
+      let(:other_object_with_different_state) { [other_data] }
+      let(:other_data) { SecureRandom.hex }
+
+      it "gives the same result for an object with the same state" do
+        expect(subject).to(
+          eq(serializer.weak_digest(other_object_with_same_state))
+        )
+      end
+
+      it "gives a different result for an object with different state" do
+        expect(subject).not_to(
+          eq(serializer.weak_digest(other_object_with_different_state))
+        )
+      end
+    end
+
+    context "when the object cannot be serialized" do
+      let(:object) { Class.new.new }
+
+      it "raises Motion::UnrepresentableStateError" do
+        expect { subject }.to raise_error(Motion::UnrepresentableStateError)
+      end
+    end
+  end
+
   describe "#serialize" do
     subject(:output) { serializer.serialize(object) }
 


### PR DESCRIPTION
This resolves a "TODO" that I had left in code. I wasn't sure what the implementation of `render_hash` should be, but after some thought and experimentation, I feel good about this.

The previous implementation was "trivially correct but wasteful". In addition to using a cryptographic hash (which we do not need in this instance), it also encrypted and signed the state of the object just to throw it away.

As it turns out, Ruby's built-in `hash` is probably good enough for our purposes. It has [64 bits of entropy](https://github.com/ruby/ruby/blob/c5eb24349a4535948514fe765c3ddb0628d81004/siphash.c#L396). This means the chance that any _two distinct values_ (we only care about pairs) share a hash is 1:2^64 (which is very unlikely!).

I was also very pleasantly surprised to find out that what I considered to be the safer implementation is faster.

```ruby
  def wasteful_render_hash
    key, _state = Motion.serializer.serialize(self)
    key
  end

  def less_wasteful_but_correct_render_hash
    Motion.serializer.weak_digest(self)
  end

  def sketchy_but_maybe_faster_render_hash
    instance_variables.reduce(0) do |accumulator, instance_variable|
      accumulator ^ instance_variable_get(instance_variable).hash
    end
  end
```

I benchmarked these on Lexie's `RestorationGame` which has quite a bit of internal state, and these were the results:
```
[13] pry(main)> n = 10_000
=> 10000
[14] pry(main)> Benchmark.bmbm do |x|
[14] pry(main)*   x.report("wasteful_render_hash") { n.times { game.wasteful_render_hash } }  
[14] pry(main)*   x.report("less_wasteful_but_correct_render_hash") { n.times { game.less_wasteful_but_correct_render_hash } }  
[14] pry(main)*   x.report("sketchy_but_maybe_faster_render_hash") { n.times { game.sketchy_but_maybe_faster_render_hash } }  
[14] pry(main)* end  
Rehearsal -------------------------------------------------------------------------
wasteful_render_hash                    0.251975   0.011690   0.263665 (  0.263763)
less_wasteful_but_correct_render_hash   0.099106   0.000000   0.099106 (  0.099109)
sketchy_but_maybe_faster_render_hash    0.156021   0.000000   0.156021 (  0.156130)
---------------------------------------------------------------- total: 0.518792sec

                                            user     system      total        real
wasteful_render_hash                    0.257864   0.000000   0.257864 (  0.258015)
less_wasteful_but_correct_render_hash   0.097058   0.000000   0.097058 (  0.097087)
sketchy_but_maybe_faster_render_hash    0.151392   0.000000   0.151392 (  0.151468)
```