### PR TITLE
Don't `preventDefault` when the component is not connected

### DIFF
--- a/javascript/AttributeTracker.js
+++ b/javascript/AttributeTracker.js
@@ -53,7 +53,9 @@ export default class AttributeTracker {
       manager = this.createManager(element)
     })
 
-    this._managers.set(element, manager)
+    if (manager) {
+      this._managers.set(element, manager)
+    }
   }
 
   _update (element) {

--- a/javascript/BindingManager.js
+++ b/javascript/BindingManager.js
@@ -39,14 +39,14 @@ export default class BindingManager {
 
   _buildHandlerForBinding ({ mode, motion }) {
     return (event) => {
-      const component = this.client.findComponent(event.target)
+      const component = this.client.getComponent(event.currentTarget)
 
-      if (component) {
-        component.processMotion(motion, event)
-
-        if (mode === MODE_HANDLE) {
-          event.preventDefault()
-        }
+      if (
+        component &&
+        component.processMotion(motion, event) &&
+        mode === MODE_HANDLE
+      ) {
+        event.preventDefault()
       }
     }
   }

--- a/javascript/Client.js
+++ b/javascript/Client.js
@@ -37,7 +37,7 @@ export default class Client {
     }
   }
 
-  findComponent (element) {
+  getComponent (element) {
     return this._componentTracker.getManager(
       element.closest(this._componentSelector)
     )

--- a/javascript/Component.js
+++ b/javascript/Component.js
@@ -29,7 +29,7 @@ export default class Component {
   processMotion (name, event = null) {
     if (!this._subscription) {
       this.client.log('Dropped motion', name, 'on', this.element)
-      return
+      return false
     }
 
     this.client.log('Processing motion', name, 'on', this.element)
@@ -43,6 +43,8 @@ export default class Component {
         event: event && serializeEvent(event, extraDataForEvent)
       }
     )
+
+    return true
   }
 
   shutdown () {

--- a/javascript/serializeEvent.js
+++ b/javascript/serializeEvent.js
@@ -69,9 +69,12 @@ function serializeElementFormData (element) {
 
   const formData = new FormData(form)
 
-  return Array.from(formData.entries())
-    .map(([key, value]) =>
-      `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+  return Array
+    .from(
+      formData.entries(),
+      ([key, value]) => (
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+      )
     )
     .join('&')
 }

--- a/lib/generators/motion/templates/motion.js
+++ b/lib/generators/motion/templates/motion.js
@@ -17,7 +17,15 @@ export default createClient({
   // made available at `Motion::Event#extra_data`:
   //
   //    getExtraDataForEvent(event) {},
+
+  // By default, the Motion client automatically disconnects all components when
+  // it detects the browser navigating away to a new page. This is done to
+  // prevent flashes of new content in components with broadcasts because of
+  // some action being taken by the controller that the user is navigating to
+  // (like submitting a form). If you do not want or need this functionally, you
+  // can turn it off:
   //
+  //    shutdownBeforeUnload: false,
 
   // The data attributes used by Motion can be customized, but these values must
   // also be updated in the Ruby initializer:
@@ -25,6 +33,5 @@ export default createClient({
   //    keyAttribute: "data-motion-key",
   //    stateAttribute: "data-motion-state",
   //    motionAttribute: "data-motion",
-  //
 
 });


### PR DESCRIPTION
This fixes a few minor issues I noticed while reviewing the client code (and trying to motivate myself to write more unit tests). The only behaviour change is that now motions that are marked as handle won't `preventDefault` if the component is not connected.

This is important because it allows a form with a `submit` Motion to fallback to a regular request.