### PR TITLE
Support Warden (and Devise) out of the box

### DIFF
--- a/lib/generators/motion/templates/motion.rb
+++ b/lib/generators/motion/templates/motion.rb
@@ -27,14 +27,15 @@ Motion.configure do |config|
   #     config.renderer_for_connection_proc = ->(websocket_connection) do
   #       ApplicationController.renderer.new(
   #         websocket_connection.env.slice(
-  #           Rack::HTTP_COOKIE,
-  #           Rack::RACK_SESSION,
+  #           Rack::HTTP_COOKIE,  # Cookies
+  #           Rack::RACK_SESSION, # Session
+  #           'warden'            # Warden (needed for `current_user` in Devise)
   #         )
   #       )
   #     end
 
   # The data attributes used by Motion can be customized, but these values must
-  # also be updated in the Ruby initializer:
+  # also be updated in the JavaScript client configuration:
   #
   #     config.key_attribute = "data-motion-key"
   #     config.state_attribute = "data-motion-state"

--- a/lib/motion/configuration.rb
+++ b/lib/motion/configuration.rb
@@ -71,6 +71,10 @@ module Motion
       `git rev-parse HEAD`.chomp
     end
 
+    # TODO: Is this always the correct key?
+    WARDEN_ENV = "warden"
+    private_constant :WARDEN_ENV
+
     option :renderer_for_connection_proc do
       ->(websocket_connection) do
         require "rack"
@@ -89,7 +93,8 @@ module Motion
         controller.renderer.new(
           websocket_connection.env.slice(
             Rack::HTTP_COOKIE,
-            Rack::RACK_SESSION
+            Rack::RACK_SESSION,
+            WARDEN_ENV
           )
         )
       end


### PR DESCRIPTION
This PR comes out of a discussion in #19 .

I don't want to include _everything_ from the env because I am not sure what things are safe to use in a long-lived, hijacked connection, but I don't see any problem with giving access to the Warden manager in addition to the session/coookies.