### PR TITLE
Markup transformer cleanup

### DIFF
--- a/lib/motion/markup_transformer.rb
+++ b/lib/motion/markup_transformer.rb
@@ -22,7 +22,7 @@ module Motion
     end
 
     def add_state_to_html(component, html)
-      return html if html.blank?
+      return if html.blank?
 
       key, state = serializer.serialize(component)
 

--- a/lib/motion/markup_transformer.rb
+++ b/lib/motion/markup_transformer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "active_support/core_ext/object/blank"
 
 require "motion"
 

--- a/spec/motion/markup_transformer_spec.rb
+++ b/spec/motion/markup_transformer_spec.rb
@@ -65,7 +65,13 @@ RSpec.describe Motion::MarkupTransformer do
     context "when the component does not generate any markup" do
       let(:html) { "" }
 
-      it { is_expected.to be_blank }
+      it { is_expected.to be_nil }
+    end
+
+    context "when the component generates only whitespace markup" do
+      let(:html) { "" }
+
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
This adds a missing require and deals with a very unlikely (but possibly problamaitc) difference between `if (! ...)` in JavaScript and `#blank?` in Ruby. 

The goal is to ensure that if the markup transformer does _not_ transform the component, [the client will surely remove it](https://github.com/unabridged/motion/blob/094bf170d9cd68274f1b18e6afcd0db6122b8b1b/javascript/reconcile.js#L8-L9). 