### PR TITLE
Callbacks for actions and connection

### DIFF
--- a/lib/motion/component/broadcasts.rb
+++ b/lib/motion/component/broadcasts.rb
@@ -75,10 +75,12 @@ module Motion
       def process_broadcast(broadcast, message)
         return unless (handler = _broadcast_handlers[broadcast])
 
-        if method(handler).arity.zero?
-          send(handler)
-        else
-          send(handler, message)
+        _run_action_callbacks do
+          if method(handler).arity.zero?
+            send(handler)
+          else
+            send(handler, message)
+          end
         end
       end
 

--- a/lib/motion/component/broadcasts.rb
+++ b/lib/motion/component/broadcasts.rb
@@ -75,7 +75,7 @@ module Motion
       def process_broadcast(broadcast, message)
         return unless (handler = _broadcast_handlers[broadcast])
 
-        _run_action_callbacks do
+        _run_action_callbacks(context: handler) do
           if method(handler).arity.zero?
             send(handler)
           else

--- a/lib/motion/component/lifecycle.rb
+++ b/lib/motion/component/lifecycle.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "active_support/callbacks"
 require "active_support/concern"
+require "active_support/deprecation"
 
 require "motion"
 
@@ -8,6 +10,12 @@ module Motion
   module Component
     module Lifecycle
       extend ActiveSupport::Concern
+
+      include ActiveSupport::Callbacks
+
+      included do
+        define_callbacks :action, :connect, :disconnect
+      end
 
       class_methods do
         # TODO: "IncorrectRevisionError" doesn't make sense for this anymore.
@@ -19,12 +27,60 @@ module Motion
             previous_revision
           )
         end
+
+        def before_action(*args, &block)
+          set_callback(:action, :before, *args, &block)
+        end
+
+        def around_action(*args, &block)
+          set_callback(:action, :around, *args, &block)
+        end
+
+        def after_action(*args, &block)
+          set_callback(:action, :after, *args, &block)
+        end
+
+        def after_connect(*args, &block)
+          set_callback(:connect, :after, *args, &block)
+        end
+
+        def after_disconnect(*args, &block)
+          set_callback(:disconnect, :after, *args, &block)
+        end
       end
 
-      def connected
+      def process_connect
+        run_callbacks(:connect)
+
+        if respond_to?(:connected)
+          ActiveSupport::Deprecation.warn(
+            "The `connected` lifecycle method is being replaced by the " \
+            "`after_connect` callback and will no longer be automatically " \
+            "invoked in the next **minor release** of Motion."
+          )
+
+          send(:connected)
+        end
       end
 
-      def disconnected
+      def process_disconnect
+        run_callbacks(:disconnect)
+
+        if respond_to?(:disconnected)
+          ActiveSupport::Deprecation.warn(
+            "The `disconnected` lifecycle method is being replaced by the " \
+            "`after_disconnect` callback and will no longer be automatically " \
+            "invoked in the next **minor release** of Motion."
+          )
+
+          send(:disconnected)
+        end
+      end
+
+      private
+
+      def _run_action_callbacks(&block)
+        run_callbacks(:action, &block)
       end
     end
   end

--- a/lib/motion/component/motions.rb
+++ b/lib/motion/component/motions.rb
@@ -47,10 +47,12 @@ module Motion
           raise MotionNotMapped.new(self, motion)
         end
 
-        if method(handler).arity.zero?
-          send(handler)
-        else
-          send(handler, event)
+        _run_action_callbacks do
+          if method(handler).arity.zero?
+            send(handler)
+          else
+            send(handler, event)
+          end
         end
       end
 

--- a/lib/motion/component/motions.rb
+++ b/lib/motion/component/motions.rb
@@ -47,7 +47,7 @@ module Motion
           raise MotionNotMapped.new(self, motion)
         end
 
-        _run_action_callbacks do
+        _run_action_callbacks(context: handler) do
           if method(handler).arity.zero?
             send(handler)
           else

--- a/lib/motion/component/periodic_timers.rb
+++ b/lib/motion/component/periodic_timers.rb
@@ -49,7 +49,9 @@ module Motion
       def process_periodic_timer(name)
         return unless (handler, _interval = _periodic_timers[name])
 
-        send(handler)
+        _run_action_callbacks do
+          send(handler)
+        end
       end
 
       private

--- a/lib/motion/component/periodic_timers.rb
+++ b/lib/motion/component/periodic_timers.rb
@@ -49,7 +49,7 @@ module Motion
       def process_periodic_timer(name)
         return unless (handler, _interval = _periodic_timers[name])
 
-        _run_action_callbacks do
+        _run_action_callbacks(context: handler) do
           send(handler)
         end
       end

--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -31,7 +31,7 @@ module Motion
         raise BlockNotAllowedError, self if block_given?
 
         html =
-          _run_action_callbacks {
+          _run_action_callbacks(context: :render) {
             _clear_awaiting_forced_rerender!
 
             view_context.capture { _without_new_instance_variables { super } }

--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -29,22 +29,28 @@ module Motion
 
       def render_in(view_context)
         raise BlockNotAllowedError, self if block_given?
-        clear_awaiting_forced_rerender!
 
-        html = view_context.capture { without_new_instance_variables { super } }
+        html =
+          _run_action_callbacks {
+            _clear_awaiting_forced_rerender!
+
+            view_context.capture { _without_new_instance_variables { super } }
+          }
+
+        raise RenderAborted, self if html == false
 
         Motion.markup_transformer.add_state_to_html(self, html)
       end
 
       private
 
-      def clear_awaiting_forced_rerender!
+      def _clear_awaiting_forced_rerender!
         return unless awaiting_forced_rerender?
 
         remove_instance_variable(RERENDER_MARKER_IVAR)
       end
 
-      def without_new_instance_variables
+      def _without_new_instance_variables
         existing_instance_variables = instance_variables
 
         yield

--- a/lib/motion/component_connection.rb
+++ b/lib/motion/component_connection.rb
@@ -24,13 +24,13 @@ module Motion
       timing("Connected") do
         @render_hash = component.render_hash
 
-        component.connected
+        component.process_connect
       end
     end
 
     def close
       timing("Disconnected") do
-        component.disconnected
+        component.process_disconnect
       end
 
       true

--- a/lib/motion/errors.rb
+++ b/lib/motion/errors.rb
@@ -52,6 +52,14 @@ module Motion
     end
   end
 
+  class RenderAborted < ComponentRenderingError
+    def initialize(component)
+      super(component, <<~MSG)
+        Rendering #{component.class} was aborted by a callback.
+      MSG
+    end
+  end
+
   class InvalidComponentStateError < ComponentError; end
 
   class UnrepresentableStateError < InvalidComponentStateError

--- a/spec/motion/channel_spec.rb
+++ b/spec/motion/channel_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Motion::Channel, type: :channel do
         )
       end
 
-      it "runs the component's `connected` callback" do
-        expect_any_instance_of(TestComponent).to receive(:connected)
+      it "runs the component's connection callbacks" do
+        expect_any_instance_of(TestComponent).to receive(:process_connect)
         subject
       end
 
@@ -126,8 +126,8 @@ RSpec.describe Motion::Channel, type: :channel do
     before(:each) { subscribe(state: state, version: version) }
 
     shared_examples "dismounted" do
-      it "runs the component's `disconnected` callback" do
-        expect_any_instance_of(TestComponent).to receive(:disconnected)
+      it "runs the component's disconnection callbacks" do
+        expect_any_instance_of(TestComponent).to receive(:process_disconnect)
         subject
       end
 

--- a/spec/motion/component/broadcasts_spec.rb
+++ b/spec/motion/component/broadcasts_spec.rb
@@ -120,9 +120,18 @@ RSpec.describe Motion::Component::Broadcasts do
 
     context "for a broadcast the component is streaming from" do
       let(:broadcast) { TestComponent::STATIC_BROADCASTS.sample }
+      let(:handler) { broadcast.to_sym }
 
       it "invokes the corresponding handler" do
-        expect(component).to receive(broadcast).with(message)
+        expect(component).to receive(handler).with(message)
+        subject
+      end
+
+      it "runs the action callbacks with the context of the handler" do
+        expect(component).to(
+          receive(:_run_action_callbacks).with(context: handler)
+        )
+
         subject
       end
     end
@@ -133,6 +142,10 @@ RSpec.describe Motion::Component::Broadcasts do
       it "does not invoke the corresponding handler" do
         expect(component).not_to receive(broadcast)
         subject
+      end
+
+      it "does not run the action callbacks" do
+        expect(component).not_to receive(:_run_action_callbacks)
       end
     end
 

--- a/spec/motion/component/lifecycle_spec.rb
+++ b/spec/motion/component/lifecycle_spec.rb
@@ -3,9 +3,6 @@
 RSpec.describe Motion::Component::Lifecycle do
   subject(:component) { TestComponent.new }
 
-  it { is_expected.to respond_to(:connected) }
-  it { is_expected.to respond_to(:disconnected) }
-
   describe described_class::ClassMethods do
     describe "#upgrade_from" do
       subject { TestComponent.upgrade_from(revision, instance) }

--- a/spec/motion/component/lifecycle_spec.rb
+++ b/spec/motion/component/lifecycle_spec.rb
@@ -4,14 +4,201 @@ RSpec.describe Motion::Component::Lifecycle do
   subject(:component) { TestComponent.new }
 
   describe described_class::ClassMethods do
+    subject(:component_class) do # We need a fresh class for every spec
+      stub_const("TemporaryComponent", Class.new(ViewComponent::Base) {
+        include Motion::Component
+
+        def noop
+          yield if block_given?
+        end
+      })
+    end
+
+    let(:component) { component_class.new }
+
     describe "#upgrade_from" do
-      subject { TestComponent.upgrade_from(revision, instance) }
+      subject { component_class.upgrade_from(revision, instance) }
 
       let(:revision) { SecureRandom.hex }
       let(:instance) { TestComponent.new }
 
       it "raises IncorrectRevisionError" do
         expect { subject }.to raise_error(Motion::IncorrectRevisionError)
+      end
+    end
+
+    describe "#before_action" do
+      subject! { component_class.before_action(:noop, **options) }
+
+      let(:options) { {} }
+
+      it "sets up an action callback" do
+        expect(component).to receive(:noop)
+        component._run_action_callbacks(context: :anything)
+      end
+
+      context "when the `only` option is used" do
+        let(:options) { {only: :matching_context} }
+
+        it "sets up an action callback that runs in the matching context" do
+          expect(component).to receive(:noop)
+          component._run_action_callbacks(context: :matching_context)
+        end
+
+        it "sets up an action callback that does *not* run in other contexts" do
+          expect(component).not_to receive(:noop)
+          component._run_action_callbacks(context: :other_context)
+        end
+      end
+
+      context "when the `except` option is used" do
+        let(:options) { {except: :matching_context} }
+
+        it "sets up a callback that does *not* run in the matching context" do
+          expect(component).not_to receive(:noop)
+          component._run_action_callbacks(context: :matching_context)
+        end
+
+        it "sets up a callback that runs in other contexts" do
+          expect(component).to receive(:noop)
+          component._run_action_callbacks(context: :other_context)
+        end
+      end
+    end
+
+    describe "#around_action" do
+      subject! { component_class.around_action(:noop, **options) }
+
+      let(:options) { {} }
+
+      it "sets up an action callback" do
+        expect(component).to receive(:noop)
+        component._run_action_callbacks(context: :anything)
+      end
+
+      context "when the `only` option is used" do
+        let(:options) { {only: :matching_context} }
+
+        it "sets up an action callback that runs in the matching context" do
+          expect(component).to receive(:noop)
+          component._run_action_callbacks(context: :matching_context)
+        end
+
+        it "sets up an action callback that does *not* run in other contexts" do
+          expect(component).not_to receive(:noop)
+          component._run_action_callbacks(context: :other_context)
+        end
+      end
+
+      context "when the `except` option is used" do
+        let(:options) { {except: :matching_context} }
+
+        it "sets up a callback that does *not* run in the matching context" do
+          expect(component).not_to receive(:noop)
+          component._run_action_callbacks(context: :matching_context)
+        end
+
+        it "sets up a callback that runs in other contexts" do
+          expect(component).to receive(:noop)
+          component._run_action_callbacks(context: :other_context)
+        end
+      end
+    end
+
+    describe "#after_action" do
+      subject! { component_class.after_action(:noop, **options) }
+
+      let(:options) { {} }
+
+      it "sets up an action callback" do
+        expect(component).to receive(:noop)
+        component._run_action_callbacks(context: :anything)
+      end
+
+      context "when the `only` option is used" do
+        let(:options) { {only: :matching_context} }
+
+        it "sets up an action callback that runs in the matching context" do
+          expect(component).to receive(:noop)
+          component._run_action_callbacks(context: :matching_context)
+        end
+
+        it "sets up an action callback that does *not* run in other contexts" do
+          expect(component).not_to receive(:noop)
+          component._run_action_callbacks(context: :other_context)
+        end
+      end
+
+      context "when the `except` option is used" do
+        let(:options) { {except: :matching_context} }
+
+        it "sets up a callback that does *not* run in the matching context" do
+          expect(component).not_to receive(:noop)
+          component._run_action_callbacks(context: :matching_context)
+        end
+
+        it "sets up a callback that runs in other contexts" do
+          expect(component).to receive(:noop)
+          component._run_action_callbacks(context: :other_context)
+        end
+      end
+    end
+
+    describe "#after_connect" do
+      subject! { component_class.after_connect(:noop) }
+
+      it "sets up a connect callback" do
+        expect(component).to receive(:noop)
+        component._run_connect_callbacks
+      end
+    end
+
+    describe "#after_disconnect" do
+      subject! { component_class.after_disconnect(:noop) }
+
+      it "sets up a disconnect callback" do
+        expect(component).to receive(:noop)
+        component._run_disconnect_callbacks
+      end
+    end
+  end
+
+  describe "#process_connect" do
+    subject { component.process_connect }
+
+    it "runs the connect callbacks" do
+      expect(component).to receive(:_run_connect_callbacks)
+      subject
+    end
+
+    context "with a component that is using the legacy lifecycle method" do
+      before(:each) { component.define_singleton_method(:connected) { nil } }
+
+      it "displays a deperacation warning and calls the legacy method" do
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(component).to receive(:connected)
+
+        subject
+      end
+    end
+  end
+
+  describe "#process_disconnect" do
+    subject { component.process_disconnect }
+
+    it "runs the disconnect callbacks" do
+      expect(component).to receive(:_run_disconnect_callbacks)
+      subject
+    end
+
+    context "with a component that is using the legacy lifecycle method" do
+      before(:each) { component.define_singleton_method(:disconnected) { nil } }
+
+      it "displays a deperacation warning and calls the legacy method" do
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(component).to receive(:disconnected)
+
+        subject
       end
     end
   end

--- a/spec/motion/component/motions_spec.rb
+++ b/spec/motion/component/motions_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe Motion::Component::Motions do
         expect(component).to receive(:noop_with_arg).with(event)
         subject
       end
+
+      it "runs the action callbacks with the context of the handler" do
+        expect(component).to(
+          receive(:_run_action_callbacks).with(context: :noop_with_arg)
+        )
+
+        subject
+      end
     end
 
     context "for a motion that does not take an event" do
@@ -86,12 +94,22 @@ RSpec.describe Motion::Component::Motions do
 
         expect(called).to be(true)
       end
+
+      it "runs the action callbacks with the context of the handler" do
+        expect(component).to(
+          receive(:_run_action_callbacks).with(context: :noop_without_arg)
+        )
+
+        subject
+      end
     end
 
     context "for a motion which is not mapped" do
       let(:motion) { "invalid_#{SecureRandom.hex}" }
 
-      it "raises MotionNotMapped" do
+      it "raises MotionNotMapped and does not run the action callbacks" do
+        expect(component).not_to receive(:_run_action_callbacks)
+
         expect { subject }.to raise_error(Motion::MotionNotMapped)
       end
     end

--- a/spec/motion/component/periodic_timers_spec.rb
+++ b/spec/motion/component/periodic_timers_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe Motion::Component::PeriodicTimers do
         expect(component).to receive(:noop)
         subject
       end
+
+      it "runs the action callbacks with the context of the handler" do
+        expect(component).to(
+          receive(:_run_action_callbacks).with(context: :noop)
+        )
+
+        subject
+      end
     end
 
     context "with a timer that is not registered" do
@@ -81,6 +89,11 @@ RSpec.describe Motion::Component::PeriodicTimers do
 
       it "does not invoke the corresponding handler" do
         expect(component).not_to receive(name)
+        subject
+      end
+
+      it "does not run the action callbacks" do
+        expect(component).not_to receive(:_run_action_callbacks)
         subject
       end
     end

--- a/spec/motion/component_connection_spec.rb
+++ b/spec/motion/component_connection_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Motion::ComponentConnection do
     end
   end
 
-  it "calls the component's #connected callback" do
-    expect_any_instance_of(TestComponent).to receive(:connected)
+  it "processes the connection on the underlying component" do
+    expect_any_instance_of(TestComponent).to receive(:process_connect)
 
     subject
   end
@@ -47,8 +47,8 @@ RSpec.describe Motion::ComponentConnection do
 
     before(:each) { component_connection }
 
-    it "calls the component's #disconnected callback" do
-      expect_any_instance_of(TestComponent).to receive(:disconnected)
+    it "processes the disconnection on the underlying component" do
+      expect_any_instance_of(TestComponent).to receive(:process_disconnect)
 
       subject
     end

--- a/spec/support/test_component.rb
+++ b/spec/support/test_component.rb
@@ -67,13 +67,8 @@ class TestComponent < ViewComponent::Base
     end
   end
 
-  def connected
-    public_send(@connected)
-  end
-
-  def disconnected
-    public_send(@disconnected)
-  end
+  after_connect { public_send(@connected) }
+  after_disconnect { public_send(@disconnected) }
 
   stream_from "noop", :noop
   map_motion :noop


### PR DESCRIPTION
This PR contains one way to address #20 . It is draft because I want to make sure that this is a feature that we want to add before I take the time to update the test suite.

It introduces the new idea of an "action" (basically anything that Motion does to a component while it is connected) and adds callbacks for it (`before_action`, `around_action`, and `after_action`). For consistency, the existing lifecycle methods for connection have also been lifted into callbacks (`after_connect` and `after_disconnect`).

#### Pros
* This would facilitate easier usage of APIs that depend on thread globals in components like [`Time.use_zone`](https://api.rubyonrails.org/classes/Time.html#method-c-use_zone), [`I18n.with_locale`](https://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests), [`Current.user`](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html), [`Papertrail.request.whodunnit`](https://github.com/paper-trail-gem/paper_trail#4-saving-more-information-about-versions) and friends, etc.
* This would bring Motion into alignment with prior art like [Stimulus Reflex](https://docs.stimulusreflex.com/lifecycle#server-side-reflex-callbacks) which added reflex callbacks in response to [a very similar issue](https://github.com/unabridged/motion/issues/20#issuecomment-653370129).
* This would allow users to DRY-up repeated code at the beginning and/or end of all "actions" on their components (a use-case unrelated to thread global management is not currently known to me, but seems likely to exist).
* This would allow users to avoid [awkward overrides](https://github.com/unabridged/motion/issues/20#issuecomment-653377971) to run code around rendering.

#### Cons
* ~~This feature may only be used by a minority of users but will [add overhead for all](https://github.com/github/view_component/pull/192#issuecomment-580746645).~~ [see [below](https://github.com/unabridged/motion/pull/27#issuecomment-656268176)]
* Callbacks have reputation for being [an anti-pattern in a lot of cases](https://samuelmullen.com/2013/05/the-problem-with-rails-callbacks/). I think the thread global management case is legitimate, but there might exist a better API for that.
* The concept of "action" is vague and was created specifically to address #20. It's possible a better abstraction exists that would handle other use-cases, map more cleanly onto existing ideas in Motion, and be more intuitive for users.
* With 1.0 on the horizon, I'm reluctant to commit to any new features in the public API since it would have to be supported until 2.0 (which I would personally prefer to never happen).

My intention is that this PR can serve as a place for a public discussion about whether adding these (or any) callbacks to Motion is a good idea.