### PR TITLE
Reformat and cleanup error messages

### DIFF
--- a/lib/motion/component/lifecycle.rb
+++ b/lib/motion/component/lifecycle.rb
@@ -10,13 +10,11 @@ module Motion
       extend ActiveSupport::Concern
 
       class_methods do
-        # TODO: "IncorrectRevisionError" doesn't make sense for this anymore.
-        # It should probably be something like "CannotUpgrade" and the error
-        # message should focus on how to handle deployments gracefully.
-        def upgrade_from(previous_revision, _instance)
-          raise IncorrectRevisionError.new(
-            Motion.config.revision,
-            previous_revision
+        def upgrade_from(previous_revision, instance)
+          raise UpgradeNotImplementedError.new(
+            instance,
+            previous_revision,
+            Motion.config.revision
           )
         end
       end

--- a/spec/motion/component/lifecycle_spec.rb
+++ b/spec/motion/component/lifecycle_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Motion::Component::Lifecycle do
       let(:revision) { SecureRandom.hex }
       let(:instance) { TestComponent.new }
 
-      it "raises IncorrectRevisionError" do
-        expect { subject }.to raise_error(Motion::IncorrectRevisionError)
+      it "raises UpgradeNotImplementedError" do
+        expect { subject }.to raise_error(Motion::UpgradeNotImplementedError)
       end
     end
   end


### PR DESCRIPTION
This PR reformat error messages so that they do not appear broken in strange places in logs and in the console.

It also updates some of the copy. In particular, `IncorrectRevisionError` has been changed to `UpgradeNotImplementedError` which more accurately reflects the situation now that upgrading is supported.