### PR TITLE
Permanent attribute

### DIFF
--- a/javascript/Client.js
+++ b/javascript/Client.js
@@ -65,5 +65,6 @@ Client.defaultOptions = {
 
   keyAttribute: 'data-motion-key',
   stateAttribute: 'data-motion-state',
-  motionAttribute: 'data-motion'
+  motionAttribute: 'data-motion',
+  permanentAttribute: 'data-motion-permanent'
 }

--- a/javascript/Component.js
+++ b/javascript/Component.js
@@ -81,7 +81,7 @@ export default class Component {
   _render (newState) {
     dispatchEvent(this.element, 'motion:before-render')
 
-    reconcile(this.element, newState, this.client.keyAttribute)
+    reconcile(this.client, this.element, newState)
 
     this.client.log('Component rendered', this.element)
 

--- a/javascript/reconcile.js
+++ b/javascript/reconcile.js
@@ -1,6 +1,8 @@
 import morphdom from 'morphdom'
 
-export default (rootElement, newState, keyAttribute) => {
+export default (client, rootElement, newState) => {
+  const { permanentAttribute, keyAttribute } = client
+
   if (typeof (newState) !== 'string') {
     throw new TypeError('Expected raw HTML for reconcile newState')
   }
@@ -39,6 +41,11 @@ export default (rootElement, newState, keyAttribute) => {
       // have been allowed to leave this function since parsing).
       fromElement.isEqualNode(toElement)
     ) {
+      return false
+    }
+
+    // Leave elements that are marked with the `permanentAttribute` alone.
+    if (fromElement.hasAttribute(permanentAttribute)) {
       return false
     }
 

--- a/lib/generators/motion/templates/motion.js
+++ b/lib/generators/motion/templates/motion.js
@@ -33,5 +33,6 @@ export default createClient({
   //    keyAttribute: "data-motion-key",
   //    stateAttribute: "data-motion-state",
   //    motionAttribute: "data-motion",
+  //    permanentAttribute: "data-motion-permanent",
 
 });

--- a/lib/generators/motion/templates/motion.rb
+++ b/lib/generators/motion/templates/motion.rb
@@ -43,5 +43,5 @@ Motion.configure do |config|
   #     config.key_attribute = "data-motion-key"
   #     config.state_attribute = "data-motion-state"
   #     config.motion_attribute = "data-motion"
-  #
+  #     config.permanent_attribute = "data-motion-permanent"
 end

--- a/lib/motion/configuration.rb
+++ b/lib/motion/configuration.rb
@@ -107,5 +107,6 @@ module Motion
     # This is included for completeness. It is not currently used internally by
     # Motion, but it might be required for building view helpers in the future.
     option(:motion_attribute) { "data-motion" }
+    option(:permanent_attribute) { "data-motion-permanent" }
   end
 end


### PR DESCRIPTION
This PR adds a configurable marker attribute (`data-motion-permanent`) that can be used to signal to the reconciliation algorithm that a subtree of the DOM should be left alone.

This is important for supporting JavaScript libraries that need to modify that DOM and is inspired by the analogous feature in [Turbolinks](https://github.com/turbolinks/turbolinks#persisting-elements-across-page-loads).