### PR TITLE
Add `error_notification_proc` configuration option

### DIFF
--- a/lib/generators/motion/templates/motion.rb
+++ b/lib/generators/motion/templates/motion.rb
@@ -37,6 +37,20 @@ Motion.configure do |config|
   #       )
   #     end
 
+  # This proc will be invoked by Motion when an unhandled error occurs. By
+  # default, an error is logged to the application's default logger but no
+  # additional action is taken. If you are using an error tracking tool like
+  # Bugsnag, Sentry, Honeybadger, or Rollbar, you can provide a proc which
+  # notifies that as well:
+  #
+  #     config.error_notification_proc = ->(error, message) do
+  #       Bugsnag.notify(error) do |report|
+  #         report.add_tab(:motion, {
+  #           message: message
+  #         })
+  #       end
+  #     end
+
   # The data attributes used by Motion can be customized, but these values must
   # also be updated in the JavaScript client configuration:
   #

--- a/lib/motion.rb
+++ b/lib/motion.rb
@@ -42,6 +42,10 @@ module Motion
     config.renderer_for_connection_proc.call(websocket_connection)
   end
 
+  def self.notify_error(error, message)
+    config.error_notification_proc&.call(error, message)
+  end
+
   # This method only exists for testing. Changing configuration while Motion is
   # in use is not supported. It is only safe to call this method when no
   # components are currently mounted.

--- a/lib/motion/configuration.rb
+++ b/lib/motion/configuration.rb
@@ -101,6 +101,8 @@ module Motion
       end
     end
 
+    option(:error_notification_proc) { nil }
+
     option(:key_attribute) { "data-motion-key" }
     option(:state_attribute) { "data-motion-state" }
 

--- a/lib/motion/log_helper.rb
+++ b/lib/motion/log_helper.rb
@@ -29,6 +29,8 @@ module Motion
       error_info = error ? ":\n#{indent(format_exception(error))}" : ""
 
       logger.error("[#{tag}] #{message}#{error_info}")
+
+      Motion.notify_error(error, message)
     end
 
     def info(message)

--- a/spec/motion/log_helper_spec.rb
+++ b/spec/motion/log_helper_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe Motion::LogHelper do
         expect(logger).to receive(:error).with(/#{Regexp.quote(tag)}/)
         subject
       end
+
+      it "notifies about the error" do
+        expect(Motion).to receive(:notify_error).with(error, message)
+        subject
+      end
     end
 
     context "with an error" do
@@ -82,6 +87,11 @@ RSpec.describe Motion::LogHelper do
           receive(:error).with(/#{Regexp.quote(error.backtrace.first)}/)
         )
 
+        subject
+      end
+
+      it "notifies about the error" do
+        expect(Motion).to receive(:notify_error).with(error, message)
         subject
       end
     end

--- a/spec/motion_spec.rb
+++ b/spec/motion_spec.rb
@@ -84,4 +84,22 @@ RSpec.describe Motion do
 
     it { is_expected.to be(renderer) }
   end
+
+  describe ".notify_error", unconfigured: true do
+    subject { described_class.notify_error(error, message) }
+
+    let(:error) { double }
+    let(:message) { double }
+
+    it "forwards the error and message to the `error_notification_proc`" do
+      Motion.configure do |config|
+        config.error_notification_proc = ->(input_error, input_message) do
+          expect(input_error).to be(error)
+          expect(input_message).to be(message)
+        end
+      end
+
+      subject
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new configuration option (`error_notification_proc`) which allows users to detect errors occurring within Motion and forward them to a custom error logging tool.