### PR TITLE
More ergonomic callbacks (`bind`)

### DIFF
--- a/lib/motion.rb
+++ b/lib/motion.rb
@@ -5,6 +5,7 @@ require "motion/errors"
 
 module Motion
   autoload :ActionCableExtentions, "motion/action_cable_extentions"
+  autoload :Callback, "motion/callback"
   autoload :Channel, "motion/channel"
   autoload :Component, "motion/component"
   autoload :ComponentConnection, "motion/component_connection"

--- a/lib/motion/callback.rb
+++ b/lib/motion/callback.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "motion"
+
+module Motion
+  class Callback
+    attr_reader :broadcast
+
+    NAMESPACE = "motion:callback"
+    private_constant :NAMESPACE
+
+    def self.broadcast_for(component, method)
+      [
+        NAMESPACE,
+        component.stable_instance_identifier_for_callbacks,
+        method
+      ].join(":")
+    end
+
+    def initialize(component, method)
+      @broadcast = self.class.broadcast_for(component, method)
+
+      component.stream_from(broadcast, method)
+    end
+
+    def ==(other)
+      other.is_a?(Callback) &&
+        other.broadcast == broadcast
+    end
+
+    def call(message = nil)
+      ActionCable.server.broadcast(broadcast, message)
+    end
+  end
+end

--- a/lib/motion/channel.rb
+++ b/lib/motion/channel.rb
@@ -65,15 +65,15 @@ module Motion
     private
 
     def synchronize
+      component_connection.if_render_required do |component|
+        transmit(renderer.render(component))
+      end
+
       streaming_from component_connection.broadcasts,
         to: :process_broadcast
 
       periodically_notify component_connection.periodic_timers,
         via: :process_periodic_timer
-
-      component_connection.if_render_required do |component|
-        transmit(renderer.render(component))
-      end
     end
 
     def handle_error(error, context)

--- a/lib/motion/component.rb
+++ b/lib/motion/component.rb
@@ -5,6 +5,7 @@ require "active_support/concern"
 require "motion"
 
 require "motion/component/broadcasts"
+require "motion/component/callbacks"
 require "motion/component/lifecycle"
 require "motion/component/motions"
 require "motion/component/periodic_timers"
@@ -15,6 +16,7 @@ module Motion
     extend ActiveSupport::Concern
 
     include Broadcasts
+    include Callbacks
     include Lifecycle
     include Motions
     include PeriodicTimers

--- a/lib/motion/component/callbacks.rb
+++ b/lib/motion/component/callbacks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+require "motion"
+
+module Motion
+  module Component
+    module Callbacks
+      def bind(method)
+        Callback.new(self, method)
+      end
+
+      def stable_instance_identifier_for_callbacks
+        @_stable_instance_identifier_for_callbacks ||= SecureRandom.uuid
+      end
+    end
+  end
+end

--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -11,6 +11,14 @@ module Motion
       RERENDER_MARKER_IVAR = :@__awaiting_forced_rerender__
       private_constant :RERENDER_MARKER_IVAR
 
+      # Some changes to Motion's state are specifically supported during render.
+      ALLOWED_NEW_IVARS_DURING_RENDER = %i[
+        @_broadcast_handlers
+        @_motion_handlers
+        @_periodic_timers
+      ].freeze
+      private_constant :ALLOWED_NEW_IVARS_DURING_RENDER
+
       def rerender!
         instance_variable_set(RERENDER_MARKER_IVAR, true)
       end
@@ -49,8 +57,11 @@ module Motion
 
         yield
       ensure
-        (instance_variables - existing_instance_variables)
-          .each(&method(:remove_instance_variable))
+        (
+          instance_variables -
+          existing_instance_variables -
+          ALLOWED_NEW_IVARS_DURING_RENDER
+        ).each(&method(:remove_instance_variable))
       end
     end
   end

--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -14,6 +14,7 @@ module Motion
       # Some changes to Motion's state are specifically supported during render.
       ALLOWED_NEW_IVARS_DURING_RENDER = %i[
         @_broadcast_handlers
+        @_stable_instance_identifier_for_callbacks
         @_motion_handlers
         @_periodic_timers
       ].freeze

--- a/spec/motion/callback_spec.rb
+++ b/spec/motion/callback_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Motion::Callback do
   describe "#==" do
     subject { callback == other }
 
-    context "with another callback for the same compoent and method" do
+    context "with another callback for the same component and method" do
       let(:other) { described_class.new(component, method) }
 
       it { is_expected.to be_truthy }

--- a/spec/motion/callback_spec.rb
+++ b/spec/motion/callback_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Motion::Callback do
+  subject(:callback) { described_class.new(component, method) }
+
+  let(:component) { TestComponent.new }
+  let(:method) { :noop }
+
+  let(:identifier) { component.stable_instance_identifier_for_callbacks }
+
+  describe ".broadcast_for" do
+    subject { described_class.broadcast_for(component, method) }
+
+    it { is_expected.to start_with("motion:callback") }
+    it { is_expected.to include(identifier.to_s) }
+    it { is_expected.to include(method.to_s) }
+  end
+
+  it "causes the component to stream from its broadcast" do
+    subject
+    expect(component.broadcasts).to include(callback.broadcast)
+  end
+
+  describe "#==" do
+    subject { callback == other }
+
+    context "with another callback for the same compoent and method" do
+      let(:other) { described_class.new(component, method) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "with another callback for a different component" do
+      let(:other) { described_class.new(different_component, method) }
+      let(:different_component) { TestComponent.new }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "with another callback for a different method" do
+      let(:other) { described_class.new(component, different_method) }
+      let(:different_method) { :change_state }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#call" do
+    subject { callback.call(message) }
+
+    let(:message) { double }
+
+    it "broadcasts the provided message to the callback topic" do
+      expect(ActionCable.server).to(
+        receive(:broadcast).with(callback.broadcast, message)
+      )
+
+      subject
+    end
+  end
+end

--- a/spec/motion/component/callbacks_spec.rb
+++ b/spec/motion/component/callbacks_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Motion::Component::Callbacks do
+  subject(:component) { TestComponent.new }
+
+  describe "#bind" do
+    subject { component.bind(method) }
+
+    let(:method) { :noop }
+
+    it "gives a callback bound to the component and method" do
+      expect(subject).to eq(Motion::Callback.new(component, method))
+    end
+  end
+
+  describe "#stable_instance_identifier_for_callbacks" do
+    subject { component.stable_instance_identifier_for_callbacks }
+
+    it "is unique to the instance" do
+      expect(subject).not_to(
+        eq(TestComponent.new.stable_instance_identifier_for_callbacks)
+      )
+    end
+
+    let(:serializer) { Motion.serializer }
+    let(:serialized) { serializer.serialize(component).last }
+    let(:deserialized) { serializer.deserialize(serialized) }
+
+    it "is preserved through serialization" do
+      expect(subject).to(
+        eq(deserialized.stable_instance_identifier_for_callbacks)
+      )
+    end
+  end
+end

--- a/spec/motion/component_spec.rb
+++ b/spec/motion/component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Motion::Component do
   subject { TestComponent }
 
   it { is_expected.to include(Motion::Component::Broadcasts) }
+  it { is_expected.to include(Motion::Component::Callbacks) }
   it { is_expected.to include(Motion::Component::Lifecycle) }
   it { is_expected.to include(Motion::Component::Motions) }
   it { is_expected.to include(Motion::Component::PeriodicTimers) }

--- a/spec/support/test_application/app/components/button_component.html.erb
+++ b/spec/support/test_application/app/components/button_component.html.erb
@@ -1,0 +1,1 @@
+<button data-motion="click"><%= text %></button>

--- a/spec/support/test_application/app/components/button_component.rb
+++ b/spec/support/test_application/app/components/button_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ButtonComponent < ViewComponent::Base
+  include Motion::Component
+
+  attr_reader :text, :on_click
+
+  def initialize(text:, on_click:)
+    @text = text
+    @on_click = on_click
+  end
+
+  map_motion :click
+
+  def click
+    on_click.call
+  end
+end

--- a/spec/support/test_application/app/components/callback_component.html.erb
+++ b/spec/support/test_application/app/components/callback_component.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <h1>The count is <%= count %>!</h1>
+
+  <%= render ButtonComponent.new(text: "+", on_click: bind(:increment)) %>
+</div>

--- a/spec/support/test_application/app/components/callback_component.rb
+++ b/spec/support/test_application/app/components/callback_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CallbackComponent < ViewComponent::Base
+  include Motion::Component
+
+  attr_reader :count
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def increment
+    @count += 1
+  end
+end

--- a/spec/support/test_application/app/controllers/callback_components_controller.rb
+++ b/spec/support/test_application/app/controllers/callback_components_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CallbackComponentsController < ApplicationController
+  def show
+    render_component_in_layout(CallbackComponent.new)
+  end
+end

--- a/spec/support/test_application/config/routes.rb
+++ b/spec/support/test_application/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resource :counter_component, only: :show
   resource :timer_component, only: :show
   resource :test_component, only: :show
+  resource :callback_component, only: :show
 
   resources :dogs, only: [:new, :create]
 end

--- a/spec/system/core_functionality_spec.rb
+++ b/spec/system/core_functionality_spec.rb
@@ -66,4 +66,13 @@ RSpec.describe "Core Functionality", type: :system do
     sleep 1
     expect(page).to have_text("0")
   end
+
+  scenario "Callbacks can be passed to children and trigger on parents" do
+    visit(callback_component_path)
+
+    expect(page).to have_text("The count is 0")
+    click_button "+"
+    click_button "+"
+    expect(page).to have_text("The count is 2")
+  end
 end


### PR DESCRIPTION
This PR comes out of a discussion in #22. ~I'm leaving it draft for now because I am not sure this is actually something that we want to do.~

Currently, the only way for a child component to communicate with a parent is with broadcasts. This works well when the purpose of communication is to signal that an external resource (like a model) has been updated, but it gets a bit awkward when the goal is to communicate something specific about the UI state of the page (like a form being "finished"). In the latter case, you need to generate and pass around a unique topic name for the broadcasts to ensure any changes are scoped to that user's view.

This introduces a new API ("callbacks" for now) that tries to make this a little less cumbersome.

Parent components can expose a method as a callback to their children using `bind` (which for ergonomics can be called both in the component class and the template):

```ruby
class CounterComponent < ViewComponent::Base
  include Motion::Component

  attr_reader :count

  def initialize(count: 0)
    @count = count
  end

  def increment
    @count += 1
  end
end
```
```erb
<div>
  <h1>The count is <%= count %>!</h1>

  <%= render ButtonComponent.new(text: "+", on_click: bind(:increment)) %>
</div>
```

Child components can receive the callback created by `bind` just like any other state, and trigger it using the `call` method:
```ruby
class ButtonComponent < ViewComponent::Base
  include Motion::Component

  attr_reader :text, :on_click

  def initialize(text:, on_click:)
    @text = text
    @on_click = on_click
  end

  map_motion :click

  def click
    on_click.call
  end
end
```
```erb
<button data-motion="click"><%= text %></button>
```

This short example is a bit contrived (Why not eliminate `ButtonComponent` completely or make it presentational and use a motion directly on `CounterComponent`?), but I think this is a reasonable feature to want in general.

That said, I have a few concerns:
* Does the convenience of this feature justify the increased complexity?
* Is "callbacks" the right name for this feature (especially given #27)?
* Is `bind` the right syntax for creating callbacks?

My intention is that this PR can serve as a place for a public discussion about whether adding this feature to Motion is a good idea.