### PR TITLE
Add compression to the serialization pipeline.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     motion (0.4.0)
+      lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)
 
@@ -97,6 +98,7 @@ GEM
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lz4-ruby (0.3.3)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     motion (0.4.0)
+      lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)
 
@@ -86,6 +87,7 @@ GEM
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lz4-ruby (0.3.3)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     motion (0.4.0)
+      lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)
 
@@ -97,6 +98,7 @@ GEM
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lz4-ruby (0.3.3)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)

--- a/gemfiles/rails_master.gemfile.lock
+++ b/gemfiles/rails_master.gemfile.lock
@@ -87,6 +87,7 @@ PATH
   remote: ..
   specs:
     motion (0.4.0)
+      lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)
 
@@ -127,6 +128,7 @@ GEM
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lz4-ruby (0.3.3)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)

--- a/motion.gemspec
+++ b/motion.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogiri"
   spec.add_dependency "rails", ">= 5.2"
+  spec.add_dependency "lz4-ruby", ">= 0.3.3"
 
   spec.post_install_message = <<~MSG
     Friendly reminder: When updating the motion gem, don't forget to update the


### PR DESCRIPTION
Add compression to the serialization pipeline. 

https://github.com/unabridged/motion/issues/33#issuecomment-657567502

I came across this comment and wondered if we could reduce the amount of data that's being sent over the wire. Using a compression library would allow us to reduce bandwidth usage by quite a bit.

Real-world tests (web console/network tab):

#### Deflate

| Compressor | Priority | Components | Raw kb | Compressed kb | Rate | Time (ms) |
|------------|----------|------------|--------|---------------|------|-----------|
| LZ4        | Speed    | 47         | 1500   | 520           | 66%  | 2.2       |
| Zlib       | Speed    | 47         | 1500   | 405           | 73%  | 10        |
| LZ4        | Speed    | 12         | 150    | 80            | 45%  | 0.4       |
| Zlib       | Speed    | 12         | 150    | 65            | 56%  | 2         |

#### Inflate

| Compressor | Components | Raw kb | Time (ms) |
|------------|------------|--------|-----------|
| LZ4        | 47         | 1500   | 1.1       |
| Zlib       | 47         | 1500   | 133       |
| LZ4        | 12         | 150    | 0.2       |
| Zlib       | 12         | 150    | 18        |

While the deflation speed of zlib is reasonable, the inflation speed turns out to be terrible.

Using a more performant compression library [(lz4)](https://github.com/komiya-atsushi/lz4-ruby) it's possible to achieve fast (de)compression while retaining reasonable compression rates. With lz4 deflation time goes down by 80% and inflation time goes down by 99% compared to zlib. Here's a general benchmark comparing lz4 to other compressors https://github.com/lz4/lz4/blob/dev/README.md#benchmarks

Thoughts?

Note: the branch is called zlib because I initially wanted to use zlib, but it turned out that the overall performance wasn't adequate, especially when dealing with web sockets where you want fast responses.