### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ Motion allows you to mount special DOM elements (henceforth "Motion components")
 - **No Full Page Reload** - The current page for a user is updated in place.
 - **Fast DOM Diffing** - DOM diffing is performed when replacing existing content with new content.
 - **Server Triggered Events** - Server-side events can trigger updates to arbitrarily many components via WebSocket channels.
-
-However Motion has a fundamentally different architecture than Stimulus Reflex and is much more like [Phoenix LiveView](https://github.com/phoenixframework/phoenix_live_view) (and even React!) in some key ways:
-
 - **Partial Page Replacement** - Motion does not use full page replacement, but rather replaces only the component on the page with new HTML, DOM diffed for performance.
 - **Encapsulated, consistent stateful components** - Components have continuous internal state that persists and updates. This means each time a component changes, new rendered HTML is generated and can replace what was there before.
 - **Blazing Fast** - Communication does not have to go through the full Rails router and controller stack. No changes to your routing or controller are required to get the full functionality of Motion.


### PR DESCRIPTION
Hey folks, I just noticed that you have some outdated and/or inaccurate information about StimulusReflex in your README.

Partial page replacement: while the default mechanism is a full page replacement, SR features three modes of operation including selector (aka partial page) replacement and no replacement (just run code).

Encapsulated, stateful components: ViewComponent is not assumed in SR, so it seems a little unfair to position this as a feature comparison. That said, ViewComponents have first-class support in both full-page and selector update operations. And for the developers who are using ViewComponent, there is [ViewComponentReflex](https://github.com/joshleblanc/view_component_reflex) which provides "continuous internal state that persists and updates".

Blazing fast: StimulusReflex doesn't go through the Rails router. By default, the full-page replacement simulates a controller action that is run in its own context that doesn't rely on routing. More importantly, selector and nothing morphs don't call any controller code at all.

You can learn more about the code paths in this [chart](https://github.com/joshleblanc/view_component_reflex).

Please let me know if you have any questions. Pleased to see things moving forward so quickly for over-the-wire applications.