### PR TITLE
Support form builder in component state

### DIFF
--- a/lib/motion/component/lifecycle.rb
+++ b/lib/motion/component/lifecycle.rb
@@ -105,8 +105,7 @@ module Motion
 
         run_callbacks(:action, &block)
       ensure
-        # `@_action_callback_context = nil` would still appear in the state
-        remove_instance_variable(:@_action_callback_context)
+        @_action_callback_context = nil
       end
     end
   end

--- a/spec/motion/component/rendering_spec.rb
+++ b/spec/motion/component/rendering_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Motion::Component::Rendering do
     it "sets the component to be rerendered" do
       expect { subject }.to(
         change { component.awaiting_forced_rerender? }
-        .from(false)
         .to(true)
       )
     end
@@ -53,7 +52,6 @@ RSpec.describe Motion::Component::Rendering do
       it "clears #awaiting_forced_rerender?" do
         expect { subject }.to(
           change { component.awaiting_forced_rerender? }
-          .from(true)
           .to(false)
         )
       end

--- a/spec/motion/component_connection_spec.rb
+++ b/spec/motion/component_connection_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe Motion::ComponentConnection do
         expect(yielded?).to be(true)
       end
     end
+
+    context "with a component that errors while rendering" do
+      before(:each) { component.rerender! }
+
+      subject do
+        component_connection.if_render_required do
+          raise "error from rendering"
+        end
+      end
+
+      it "logs the error" do
+        expect(Rails.logger).to receive(:error).with(/error from rendering/)
+        subject
+      end
+    end
   end
 
   describe "#broadcasts" do

--- a/spec/support/test_application/app/components/dog_form_component.html.erb
+++ b/spec/support/test_application/app/components/dog_form_component.html.erb
@@ -5,5 +5,13 @@
         <%= f.object.errors[:name].to_sentence %>
     </div>
 
+    <div>
+        <%= f.fields_for :toys do |f| %>
+            <%= render ToyFieldsComponent.new(f: f) %>
+        <% end %>
+
+        <button data-motion="add_toy">Add Toy</button>
+    </div>
+
     <%= f.submit %>
 <% end %>

--- a/spec/support/test_application/app/components/dog_form_component.rb
+++ b/spec/support/test_application/app/components/dog_form_component.rb
@@ -9,15 +9,37 @@ class DogFormComponent < ViewComponent::Base
     @dog = dog
   end
 
-  stream_from "dogs:created", :handle_dog_created
   map_motion :validate
 
   def validate(event)
-    dog.assign_attributes(event.form_data.require(:dog).permit(:name))
+    clear_unidentifiable_toys
+
+    dog.assign_attributes(dog_params(event.form_data))
     dog.validate
   end
 
+  map_motion :add_toy
+
+  def add_toy
+    dog.toys.build
+  end
+
+  stream_from "dogs:created", :handle_dog_created
+
   def handle_dog_created(_new_id)
     dog.validate
+  end
+
+  private
+
+  # TODO: This is required because `accepts_nested_attributes_for` doesn't have
+  # a way to identify unpersisted records which makes assignment non-idempotent.
+  # It would be ideal to fix the problem there.
+  def clear_unidentifiable_toys
+    dog.toys.target&.select!(&:persisted?)
+  end
+
+  def dog_params(params)
+    params.require(:dog).permit(:name, toys_attributes: [:id, :name])
   end
 end

--- a/spec/support/test_application/app/components/toy_fields_component.html.erb
+++ b/spec/support/test_application/app/components/toy_fields_component.html.erb
@@ -1,0 +1,5 @@
+<div>
+    <%= f.label :name, 'Toy' %>
+    <%= f.text_field :name %>
+    <%= f.object.errors[:name].to_sentence %>
+</div>

--- a/spec/support/test_application/app/components/toy_fields_component.html.erb
+++ b/spec/support/test_application/app/components/toy_fields_component.html.erb
@@ -1,5 +1,6 @@
 <div>
     <%= f.label :name, 'Toy' %>
-    <%= f.text_field :name %>
+    <%= f.text_field :name,
+        data: { identifier_for_test_suite: "toy-name[#{f.index}]" } %>
     <%= f.object.errors[:name].to_sentence %>
 </div>

--- a/spec/support/test_application/app/components/toy_fields_component.rb
+++ b/spec/support/test_application/app/components/toy_fields_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ToyFieldsComponent < ViewComponent::Base
+  include Motion::Component
+
+  attr_reader :f
+
+  def initialize(f:)
+    @f = f
+  end
+end

--- a/spec/support/test_application/app/controllers/dogs_controller.rb
+++ b/spec/support/test_application/app/controllers/dogs_controller.rb
@@ -6,8 +6,14 @@ class DogsController < ApplicationController
   end
 
   def create
-    Dog.create!(params.require(:dog).permit(:name))
+    Dog.create!(dog_params)
 
     redirect_to(new_dog_path)
+  end
+
+  private
+
+  def dog_params
+    params.require(:dog).permit(:name, toys_attributes: [:id, :name])
   end
 end

--- a/spec/support/test_application/app/models/dog.rb
+++ b/spec/support/test_application/app/models/dog.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class Dog < ApplicationRecord
+  has_many :toys, dependent: :destroy
+
   validates :name, uniqueness: true, presence: true
 
   after_commit :broadcast_created!, on: :create
+
+  accepts_nested_attributes_for :toys
 
   private
 

--- a/spec/support/test_application/app/models/toy.rb
+++ b/spec/support/test_application/app/models/toy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Toy < ApplicationRecord
+  belongs_to :dog
+
+  validates :name, presence: true
+end

--- a/spec/support/test_application/db/schema.rb
+++ b/spec/support/test_application/db/schema.rb
@@ -7,4 +7,12 @@ ActiveRecord::Schema.define do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "toys", force: :cascade do |t|
+    t.integer "dog_id", null: false
+    t.string "name", null: false
+
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/spec/system/live_validating_form_demo_spec.rb
+++ b/spec/system/live_validating_form_demo_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe "Live Validating Form Demo", type: :system do
 
     expect(page).to have_text("taken")
   end
+
+  it "works with nested attributes" do
+    fill_in "dog_name", with: "Fido"
+
+    click_button "Add Toy"
+
+    fill_in "dog_toys_attributes_0_name", with: "Ball"
+
+    expect(page).not_to have_text("can't be blank")
+
+    click_button "Add Toy"
+
+    fill_in "dog_toys_attributes_0_name", with: ""
+    fill_in "dog_toys_attributes_1_name", with: "Ball"
+    blur
+
+    expect(page).to have_text("can't be blank")
+  end
 end

--- a/spec/system/live_validating_form_demo_spec.rb
+++ b/spec/system/live_validating_form_demo_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe "Live Validating Form Demo", type: :system do
 
     click_button "Add Toy"
 
-    fill_in "dog_toys_attributes_0_name", with: "Ball"
+    find('[data-identifier-for-test-suite="toy-name[0]"]').fill_in(with: "Ball")
 
     expect(page).not_to have_text("can't be blank")
 
     click_button "Add Toy"
 
-    fill_in "dog_toys_attributes_0_name", with: ""
-    fill_in "dog_toys_attributes_1_name", with: "Ball"
+    find('[data-identifier-for-test-suite="toy-name[0]"]').fill_in(with: "")
+    find('[data-identifier-for-test-suite="toy-name[1]"]').fill_in(with: "Ball")
     blur
 
     expect(page).to have_text("can't be blank")


### PR DESCRIPTION
This fixes #41 .

The problem turned out to be that the form builder contained a reference back to the template to which it is rendering (the component itself) and the component could not be serialized while it was being rendered. This removes the old `_without_new_instance_variables` approach in favour of a deny list of ivars that cannot be stored in state, and then provides a Marshall implementation that can work at any time.

It also add a systems test that shows nested fields working (the goal of #41).