### PR TITLE
Fix using asset-related helpers in components

### DIFF
--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -23,6 +23,9 @@ module Motion
         @controller
         @request
         @tag_builder
+
+        @asset_resolver_strategies
+        @assets_environment
       ].freeze
 
       private_constant :STATE_EXCLUDED_IVARS


### PR DESCRIPTION
Assets helpers end up creating exotic state which cannot be serialized.
We found that these two were generated by image_tag.