### PR TITLE
Don't use a layout when rendering for cable

### DIFF
--- a/lib/motion/configuration.rb
+++ b/lib/motion/configuration.rb
@@ -81,16 +81,6 @@ module Motion
         require "rack"
         require "action_controller"
 
-        # Make a special effort to use the host application's base controller
-        # in case the CSRF protection has been customized, but don't couple to
-        # a particular constant from the outer application.
-        controller =
-          if defined?(ApplicationController)
-            ApplicationController
-          else
-            ActionController::Base
-          end
-
         controller.renderer.new(
           websocket_connection.env.slice(
             Rack::HTTP_COOKIE,
@@ -98,6 +88,23 @@ module Motion
             WARDEN_ENV
           )
         )
+      end
+    end
+
+    def controller
+      Class.new(controller_superclass) do
+        layout false
+      end
+    end
+
+    # Make a special effort to use the host application's base controller
+    # in case the CSRF protection has been customized, but don't couple to
+    # a particular constant from the outer application.
+    def controller_superclass
+      if defined?(ApplicationController)
+        ApplicationController
+      else
+        ActionController::Base
       end
     end
 

--- a/spec/motion/component/rendering_spec.rb
+++ b/spec/motion/component/rendering_spec.rb
@@ -27,7 +27,13 @@ RSpec.describe Motion::Component::Rendering do
   end
 
   describe ".render_in" do
-    subject { ApplicationController.render(component) }
+    let(:controller) do
+      Class.new(ApplicationController) do
+        layout false
+      end
+    end
+
+    subject { controller.render(component) }
 
     it "transforms the rendered markup" do
       expect(subject).to(

--- a/spec/motion/configuration_spec.rb
+++ b/spec/motion/configuration_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Motion::Configuration do
       let(:cookies) { {"bar" => "baz"} }
 
       it "builds a renderer from the ApplicationController" do
-        expect(subject.controller).to eq(ApplicationController)
+        expect(subject.controller.superclass).to eq(ApplicationController)
       end
 
       it "builds a render which has access to the session" do
@@ -76,7 +76,7 @@ RSpec.describe Motion::Configuration do
         before(:each) { hide_const("ApplicationController") }
 
         it "builds a renderer from ActionController::Base" do
-          expect(subject.controller).to eq(ActionController::Base)
+          expect(subject.controller.superclass).to eq(ActionController::Base)
         end
       end
     end


### PR DESCRIPTION
DRAFT: This PR does not fix tests broken by Rails 6.1 but has been opened to start a conversation. The changes made do fix the bug in a real-world application but have not yet been back-tested in Rails < 6.1. Before backwards compatibility is tested, I would like to get the specs working but I'm having trouble understanding why the tests fail given the same components work in a real test application.

-------

Fixes #71 

In Rails < 6.1, ViewComponent includes a monkey patch for the
`render_in` method that bypasses the Rails rendered.

Unfortunately, the offical `render_in` method renders the component
within the context of the full page, rather than in isolation. When
morphdom receives a payload that is of a different type to the original
(full document vs element/node) it deletes the element on the page and
attempts (and fails) to replace it with the full document.

Using an anonymous class with layout set to false tells Rails not to
render the rest of the page