### PR TITLE
Fix intermittent system test failure

### DIFF
--- a/spec/support/system_test_helpers.rb
+++ b/spec/support/system_test_helpers.rb
@@ -17,9 +17,9 @@ module SystemTestHelpers
   end
 
   # Blocks until a component renders (since the last call)
-  def wait_for_render
+  def wait_for_render(&block)
     wait_for_action_cable_idle
-    wait_for_expression_to_increase(JS_RENDER_COUNT)
+    wait_for_expression_to_increase(JS_RENDER_COUNT, &block)
   end
 
   private
@@ -34,11 +34,13 @@ module SystemTestHelpers
     end
   end
 
-  def wait_for_expression_to_increase(expression)
+  def wait_for_expression_to_increase(expression, &block)
     last_values = (@_wait_for_expression_to_increase_state ||= Hash.new(0))
 
     last_value = last_values[expression]
     new_value = nil
+
+    block&.call
 
     block_until { (new_value = page.evaluate_script(expression)) > last_value }
 

--- a/spec/system/live_validating_form_demo_spec.rb
+++ b/spec/system/live_validating_form_demo_spec.rb
@@ -16,15 +16,19 @@ RSpec.describe "Live Validating Form Demo", type: :system do
   it "automatically validates after user input" do
     Dog.create!(name: "Taken")
 
-    find("#dog_name").click
-    fill_in "dog_name", with: "Taken"
-    blur
-    wait_for_render
+    wait_for_render do
+      find("#dog_name").click
+
+      fill_in "dog_name", with: "Taken"
+      blur
+    end
 
     expect(page).to have_text("taken")
 
-    fill_in "dog_name", with: "Available"
-    blur
+    wait_for_render do
+      fill_in "dog_name", with: "Available"
+      blur
+    end
 
     expect(page).not_to have_text("taken")
   end
@@ -43,27 +47,29 @@ RSpec.describe "Live Validating Form Demo", type: :system do
   end
 
   it "works with nested attributes" do
-    fill_in "dog_name", with: "Fido"
+    wait_for_render do
+      fill_in "dog_name", with: "Fido"
+      blur
+    end
 
-    click_button "Add Toy"
-    wait_for_render
+    wait_for_render do
+      click_button "Add Toy"
+    end
 
-    find('[data-identifier-for-test-suite="toy-name[0]"]').fill_in(with: "Ball")
+    wait_for_render do
+      find('[data-identifier-for-test-suite="toy-name[0]"]').fill_in(with: "Ball")
+      click_button "Add Toy"
+    end
 
     expect(page).not_to have_text("can't be blank")
 
-    click_button "Add Toy"
-    wait_for_render
-
-    find('[data-identifier-for-test-suite="toy-name[1]"]').click
-    fill_in '[data-identifier-for-test-suite="toy-name[1]"]', with: "Ball"
-    blur
-    wait_for_render
-
-    find('[data-identifier-for-test-suite="toy-name[0]"]').click
-    fill_in '[data-identifier-for-test-suite="toy-name[0]"]', with: ""
-    blur
-    wait_for_render
+    wait_for_render do
+      find('[data-identifier-for-test-suite="toy-name[0]"]').click
+      find('[data-identifier-for-test-suite="toy-name[0]"]').fill_in(with: "")
+      find('[data-identifier-for-test-suite="toy-name[1]"]').click
+      find('[data-identifier-for-test-suite="toy-name[1]"]').fill_in(with: "Ball")
+      blur
+    end
 
     expect(page).to have_text("can't be blank")
   end

--- a/spec/system/live_validating_form_demo_spec.rb
+++ b/spec/system/live_validating_form_demo_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Live Validating Form Demo", type: :system do
   it "automatically validates after user input" do
     Dog.create!(name: "Taken")
 
+    find("#dog_name").click
     fill_in "dog_name", with: "Taken"
     blur
     wait_for_render
@@ -54,8 +55,13 @@ RSpec.describe "Live Validating Form Demo", type: :system do
     click_button "Add Toy"
     wait_for_render
 
-    find('[data-identifier-for-test-suite="toy-name[0]"]').fill_in(with: "")
-    find('[data-identifier-for-test-suite="toy-name[1]"]').fill_in(with: "Ball")
+    find('[data-identifier-for-test-suite="toy-name[1]"]').click
+    fill_in '[data-identifier-for-test-suite="toy-name[1]"]', with: "Ball"
+    blur
+    wait_for_render
+
+    find('[data-identifier-for-test-suite="toy-name[0]"]').click
+    fill_in '[data-identifier-for-test-suite="toy-name[0]"]', with: ""
     blur
     wait_for_render
 


### PR DESCRIPTION
# Description

Attempts to fix intermittent system test failure:
https://travis-ci.com/github/unabridged/motion/jobs/490209306
https://travis-ci.com/github/unabridged/motion/jobs/490205207

The stale element error from Selenium tells me motion re-renders between selenium finding an element and filling it in.  The failure of the 'Taken' test with a 'Name cannot be blank' error shows that a motion is getting triggered too soon or is not registering the `fill_in` of Taken.  When I [added some logging](https://travis-ci.com/github/unabridged/motion/jobs/492128950) to that test, I could see below that motion was getting triggered on the 'T' of 'Taken', but the formdata showed a dog_name of empty and T, such that it re-rendered for the first time as nil.

```
validate: 
#<Motion::Event:0x00000000022ae2a0
  @raw={
    "type"=>"change", "details"=>{}, "extraData"=>nil,
    "target"=>{"tagName"=>"INPUT", "value"=>"T", "attributes"=>{"type"=>"text", "name"=>"dog[name]", "id"=>"dog_name"}, 
    "formData"=>"utf8=%E2%9C%93&authenticity_token=D29EbbCr98xLYlzttbok%2BqZ%2BWUwIEH0zgVqDU4RSMC9SapAuVIRw2UGbcPQz7V5%2BnPu%2Bn29zAxNGeKndhHRE%2FA%3D%3D&dog%5Bname%5D=T&dog%5Bname%5D="
   }
...
>
```

I tried a few solutions, including changing the input to map a motion on blur, instead of the form on change, but I decided we wanted to be able to write a system test like this, on change.  


In the end the solution for these errors seems to be:
*  This [capybara issue](https://github.com/teamcapybara/capybara/issues/2342) suggested adding a click before finding if there was a timing issue.
* Making `waiting_for_render` a method that accepted a block, so we could be sure we were waiting for the right rendering to happen

I tested this fix [four times](https://travis-ci.com/github/unabridged/motion/builds), and it appears to be working.

