### PR TITLE
Fix loading error with webpack 6+

### DIFF
--- a/javascript/Component.js
+++ b/javascript/Component.js
@@ -2,7 +2,8 @@ import dispatchEvent from './dispatchEvent'
 import serializeEvent from './serializeEvent'
 import reconcile from './reconcile'
 
-import { version } from '../package.json'
+import packageInfo from '../package.json'
+const { version } = packageInfo
 
 export default class Component {
   constructor (client, element) {


### PR DESCRIPTION
When trying to upgrade a Rails app from webpacker 5 to 6, I got the following error when launching webpack-dev-server:

    ERROR in ./node_modules/@unabridged/motion/javascript/Component.js 19:8-15
    Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)

It turns out I had to upgrade to webpack 5.x which provokes this error. If I understand the webpacker
README correctly, webpack 5.x is already supposed to be supported in webpacker 5. Unclear to me if
it's the default or if people sticked with webpack 4.x after partial upgrades.

Imo the change looks safe, but we may want to upgrade to webpack 5 in the test application to be sure.
I tried to do so but got cryptic JS errors, and I'm unsure if you want to support both webpack 4.x and
webpack 5.x in this project. I'm ready to try shaving this yak but I'll happily take your opinion
before doing so ;-)

Thanks!
