### PR TITLE
Moved marshal_dump into public scope.

### DIFF
--- a/lib/motion/component/rendering.rb
+++ b/lib/motion/component/rendering.rb
@@ -60,17 +60,17 @@ module Motion
 
         Motion.markup_transformer.add_state_to_html(self, html)
       end
+      
+      def marshal_dump
+        (instance_variables - STATE_EXCLUDED_IVARS)
+          .map { |ivar| [ivar, instance_variable_get(ivar)] }
+          .to_h
+      end
 
       private
 
       def _clear_awaiting_forced_rerender!
         @_awaiting_forced_rerender = false
-      end
-
-      def marshal_dump
-        (instance_variables - STATE_EXCLUDED_IVARS)
-          .map { |ivar| [ivar, instance_variable_get(ivar)] }
-          .to_h
       end
 
       def marshal_load(instance_variables)


### PR DESCRIPTION
The `Serializer` class is attempting to call the private method `marshal_dump` for components. This happens when it is attempting to collect instance variables due to a failing dump.

I don't have the time to write a better fix, so i've just moved the method into public scope.

https://github.com/unabridged/motion/blob/7e1bc4bce9d707f19a22f3231e72957c575e8241/lib/motion/serializer.rb#L68-L77