### PR TITLE
Inclusive marshal_dump For Component Attributes

### DIFF
--- a/lib/motion/serializer.rb
+++ b/lib/motion/serializer.rb
@@ -70,7 +70,7 @@ module Motion
     rescue TypeError => e
       failing_ivars = []
 
-      component.marshal_dump.each do |ivar_name, ivar_value|
+      component.send(:marshal_dump).each do |ivar_name, ivar_value|
         dump!(ivar_value)
       rescue TypeError
         failing_ivars << ivar_name

--- a/spec/support/test_application/app/components/button_component.rb
+++ b/spec/support/test_application/app/components/button_component.rb
@@ -5,6 +5,8 @@ class ButtonComponent < ViewComponent::Base
 
   attr_reader :text, :on_click
 
+  serializes :text, :on_click
+
   def initialize(text:, on_click:)
     @text = text
     @on_click = on_click

--- a/spec/support/test_application/app/components/callback_component.rb
+++ b/spec/support/test_application/app/components/callback_component.rb
@@ -5,6 +5,8 @@ class CallbackComponent < ViewComponent::Base
 
   attr_reader :count
 
+  serializes :count
+
   def initialize(count: 0)
     @count = count
   end

--- a/spec/support/test_application/app/components/counter_component.rb
+++ b/spec/support/test_application/app/components/counter_component.rb
@@ -5,6 +5,8 @@ class CounterComponent < ViewComponent::Base
 
   attr_reader :count, :child
 
+  serializes :count, :child
+
   def initialize(count: 0)
     @count = count
     @child = nil

--- a/spec/support/test_application/app/components/dog_form_component.rb
+++ b/spec/support/test_application/app/components/dog_form_component.rb
@@ -5,6 +5,8 @@ class DogFormComponent < ViewComponent::Base
 
   attr_reader :dog
 
+  serializes :dog
+
   def initialize(dog: Dog.new)
     @dog = dog
   end

--- a/spec/support/test_application/app/components/timer_component.rb
+++ b/spec/support/test_application/app/components/timer_component.rb
@@ -3,6 +3,8 @@
 class TimerComponent < ViewComponent::Base
   include Motion::Component
 
+  serializes :seconds
+
   def initialize(seconds: 1)
     @seconds = seconds
   end

--- a/spec/support/test_application/app/components/toy_fields_component.rb
+++ b/spec/support/test_application/app/components/toy_fields_component.rb
@@ -5,6 +5,8 @@ class ToyFieldsComponent < ViewComponent::Base
 
   attr_reader :f
 
+  serializes :f
+
   def initialize(f:)
     @f = f
   end

--- a/spec/support/test_component.rb
+++ b/spec/support/test_component.rb
@@ -6,6 +6,13 @@ require "motion"
 class TestComponent < ViewComponent::Base
   include Motion::Component
 
+  # used by tests that want to know the initial ivars
+  STATIC_IVARS = %i[
+    @connected
+    @disconnected
+    @count
+  ]
+
   # used by tests that want to know the initial motions
   STATIC_MOTIONS = %w[
     noop
@@ -13,6 +20,7 @@ class TestComponent < ViewComponent::Base
     noop_without_arg
     change_state
     force_rerender
+    setup_dynamic_ivar
     setup_dynamic_motion
     setup_dynamic_stream
     setup_dynamic_timer
@@ -26,6 +34,7 @@ class TestComponent < ViewComponent::Base
     noop_without_arg
     change_state
     force_rerender
+    setup_dynamic_ivar
     setup_dynamic_motion
     setup_dynamic_stream
     setup_dynamic_timer
@@ -37,6 +46,7 @@ class TestComponent < ViewComponent::Base
     noop
     change_state
     force_rerender
+    setup_dynamic_ivar
     setup_dynamic_motion
     setup_dynamic_stream
     setup_dynamic_timer
@@ -44,6 +54,8 @@ class TestComponent < ViewComponent::Base
   ].freeze
 
   attr_reader :count
+
+  serializes :connected, :disconnected, :count
 
   def initialize(connected: :noop, disconnected: :noop, count: 0)
     @connected = connected
@@ -103,6 +115,18 @@ class TestComponent < ViewComponent::Base
 
   def force_rerender(*)
     rerender!
+  end
+
+  stream_from "setup_dynamic_ivar", :setup_dynamic_ivar
+  map_motion :setup_dynamic_ivar
+  every 10_000.years, :setup_dynamic_ivar
+
+  # used for tests that want to detect this dynamic ivar being setup
+  DYNAMIC_IVAR = :@dynamic_ivar
+
+  def setup_dynamic_ivar(*)
+    instance_variable_set(DYNAMIC_IVAR, true)
+    serializes DYNAMIC_IVAR
   end
 
   stream_from "setup_dynamic_motion", :setup_dynamic_motion


### PR DESCRIPTION
### WHAT
This change is an attempt to create an inclusive dump for component attributes.

### WHY
This would allow for custom attributes that can be ignored by motion. By doing so, we gain these benefits:
1. Better gem compatibility.
2. More performant components by using instance variables for storing results that do not need to be saved to the state.