### PR TITLE
Checkbox support

### DIFF
--- a/javascript/serializeEvent.js
+++ b/javascript/serializeEvent.js
@@ -39,13 +39,14 @@ function serializeEventDetails (event) {
 function serializeElement (element) {
   if (!element) return {}
 
-  const { tagName, value } = element
+  const { tagName, value, checked } = element
   const attributes = serializeElementAttributes(element)
   const formData = serializeElementFormData(element)
 
   return {
     tagName,
     value,
+    checked,
     attributes,
     formData
   }

--- a/lib/motion/element.rb
+++ b/lib/motion/element.rb
@@ -22,6 +22,10 @@ module Motion
       raw["value"]
     end
 
+    def checked?
+      raw["checked"]
+    end
+
     def attributes
       raw.fetch("attributes", {})
     end

--- a/spec/motion/element_spec.rb
+++ b/spec/motion/element_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Motion::Element do
       {
         "tagName" => "INPUT",
         "value" => "test",
+        "checked" => false,
         "attributes" => {
           "class" => "form-control",
           "data-field" => "name",
@@ -50,6 +51,12 @@ RSpec.describe Motion::Element do
       subject { element.value }
 
       it { is_expected.to eq("test") }
+    end
+
+    describe "#checked?" do
+      subject { element.checked? }
+
+      it { is_expected.to eq(false) }
     end
 
     describe "#attributes" do

--- a/spec/support/test_application/app/components/checkbox_component.html.erb
+++ b/spec/support/test_application/app/components/checkbox_component.html.erb
@@ -1,0 +1,18 @@
+<div>
+  <h1>
+    <% if checked? %>
+      The checkbox is checked.
+    <% else %>
+      The checkbox is <strong>not</strong> checked.
+    <% end %>
+  </h1>
+
+  <%=
+    check_box_tag(
+      'checkbox',
+      '1',
+      checked,
+      data: { motion: 'change->update_checked' }
+    )
+  %>
+</div>

--- a/spec/support/test_application/app/components/checkbox_component.rb
+++ b/spec/support/test_application/app/components/checkbox_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CheckboxComponent < ViewComponent::Base
+  include Motion::Component
+
+  attr_reader :checked
+  alias_method :checked?, :checked
+
+  def initialize
+    @checked = false
+  end
+
+  map_motion :update_checked
+
+  def update_checked(event)
+    @checked = event.target.checked?
+  end
+end

--- a/spec/support/test_application/app/controllers/checkbox_components_controller.rb
+++ b/spec/support/test_application/app/controllers/checkbox_components_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckboxComponentsController < ApplicationController
+  def show
+    render_component_in_layout(CheckboxComponent.new)
+  end
+end

--- a/spec/support/test_application/config/routes.rb
+++ b/spec/support/test_application/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resource :timer_component, only: :show
   resource :test_component, only: :show
   resource :callback_component, only: :show
+  resource :checkbox_component, only: :show
 
   resources :dogs, only: [:new, :create]
 end

--- a/spec/system/core_functionality_spec.rb
+++ b/spec/system/core_functionality_spec.rb
@@ -95,4 +95,21 @@ RSpec.describe "Core Functionality", type: :system do
 
     expect(page).to have_text("The count is 2")
   end
+
+  scenario "Reading the checked state of checkboxes from events" do
+    visit(checkbox_component_path)
+    wait_for_connect
+
+    expect(page).to have_text("The checkbox is not checked")
+
+    find("#checkbox").click
+    wait_for_render
+
+    expect(page).to have_text("The checkbox is checked")
+
+    find("#checkbox").click
+    wait_for_render
+
+    expect(page).to have_text("The checkbox is not checked")
+  end
 end


### PR DESCRIPTION
This PR allow reading the checked state of form elements (like checkboxes and radio buttons) with `Motion::Element#checked?`.