### PR TITLE
🚢 Bump version for 0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Unreleased
 
+## 0.7 - 2022-06-16
+
+* Features
+  * Allow accessing the checked state of form controls via `Motion::Element#checked?` ([#152](https://github.com/unabridged/motion/pull/152))
+
 ## 0.6 - 2022-03-16
 
 * Fixes
-  * Support ViewComponent > 2.35.0 ([#](https://github.com/unabridged/motion/pull/79))
+  * Support ViewComponent > 2.35.0 ([#79](https://github.com/unabridged/motion/pull/79))
 
 ## 0.5 - 2021-03-11
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    motion (0.5.0)
+    motion (0.7.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.5.0)
+    motion (0.7.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.5.0)
+    motion (0.7.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.5.0)
+    motion (0.7.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.5.0)
+    motion (0.7.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -95,7 +95,7 @@ GIT
 PATH
   remote: ..
   specs:
-    motion (0.5.0)
+    motion (0.7.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/lib/motion/version.rb
+++ b/lib/motion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motion
-  VERSION = "0.5.0"
+  VERSION = "0.7.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unabridged/motion",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "description": "Reactive view components written in Ruby for Rails",
   "main": "javascript/index.js",
   "files": [


### PR DESCRIPTION
This PR updates the change log and bumps the version of the Gem an NPM package for the 0.7 release.

After this PR is merged, I will run the `bin/rake release` command which will publish the Gem and package.