### PR TITLE
Fix Consumer Doubling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    motion (0.7.0)
+    motion (0.7.1)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.7.0)
+    motion (0.7.1)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.7.0)
+    motion (0.7.1)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.7.0)
+    motion (0.7.1)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    motion (0.7.0)
+    motion (0.7.1)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -95,7 +95,7 @@ GIT
 PATH
   remote: ..
   specs:
-    motion (0.7.0)
+    motion (0.7.1)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.2)

--- a/javascript/Client.js
+++ b/javascript/Client.js
@@ -8,6 +8,8 @@ export default class Client {
   constructor (options = {}) {
     Object.assign(this, Client.defaultOptions, options)
 
+    this.consumer = this.consumer || getFallbackConsumer()
+
     this._componentSelector = `[${this.keyAttribute}][${this.stateAttribute}]`
 
     this._componentTracker =
@@ -51,10 +53,6 @@ export default class Client {
 }
 
 Client.defaultOptions = {
-  get consumer () {
-    return getFallbackConsumer()
-  },
-
   getExtraDataForEvent (_event) {
     // noop
   },

--- a/javascript/Component.js
+++ b/javascript/Component.js
@@ -34,15 +34,16 @@ export default class Component {
         received: newState => this._render(newState)
       }
     )
+    this._initialSubscription = subscription
   }
 
   processMotion (name, event = null, element = event && event.currentTarget) {
     if (!this._subscription) {
-      this.client.log('Dropped motion', name, 'on', this.element)
+      this.client.log('Dropped motion', name, 'on', this)
       return false
     }
 
-    this.client.log('Processing motion', name, 'on', this.element)
+    this.client.log('Processing motion', name, 'on', this)
 
     const extraDataForEvent = event && this.client.getExtraDataForEvent(event)
 
@@ -69,25 +70,25 @@ export default class Component {
   }
 
   _beforeConnect () {
-    this.client.log('Connecting component', this.element)
+    this.client.log('Connecting component', this)
 
     dispatchEvent(this.element, 'motion:before-connect')
   }
 
   _connect () {
-    this.client.log('Component connected', this.element)
+    this.client.log('Component connected', this)
 
     dispatchEvent(this.element, 'motion:connect')
   }
 
   _connectFailed () {
-    this.client.log('Failed to connect component', this.element)
+    this.client.log('Failed to connect component', this)
 
     dispatchEvent(this.element, 'motion:connect-failed')
   }
 
   _disconnect () {
-    this.client.log('Component disconnected', this.element)
+    this.client.log('Component disconnected', this)
 
     dispatchEvent(this.element, 'motion:disconnect')
   }
@@ -97,7 +98,7 @@ export default class Component {
 
     reconcile(this.element, newState, this.client.keyAttribute)
 
-    this.client.log('Component rendered', this.element)
+    this.client.log('Component rendered', this)
 
     dispatchEvent(this.element, 'motion:render')
   }

--- a/lib/motion/version.rb
+++ b/lib/motion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motion
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unabridged/motion",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Reactive view components written in Ruby for Rails",
   "main": "javascript/index.js",
   "files": [


### PR DESCRIPTION
When a consumer option is supplied to motion's `createClient`, the `consumer` getter in `Client.defaultOptions` still gets called during `Object.assign`, so `getFallbackConsumer` still gets called and generates an additional ActionCable consumer.

This PR moves consumer presence checking to an explicit statement after `Object.assign`.

Also improves the logging of `Component` lifecycle events by attaching the component itself to the logs.

Finally, bumps version to 0.7.1